### PR TITLE
Endre måten vi logger til Securelogs på

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ jobs:
     uses: navikt/toi-github-actions-workflows/.github/workflows/build-and-deploy.yaml@main
     with:
       java-version: '21'
-      deploy-to-dev-if-branch-name-is: 'oppgrader-avhengigheter'
+      deploy-to-dev-if-branch-name-is: 'securelogs'
     permissions:
       contents: read
       id-token: write

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -5,10 +5,10 @@ import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxy
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.ProxyConfig
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.error.exceptions.AltinnrettigheterProxyKlientException
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.*
+import no.nav.arbeidsgiver.toi.presentertekandidater.SecureLogLogger.Companion.secure
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.ENKELTRETTIGHET_REKRUTTERING
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.INGEN
 import no.nav.arbeidsgiver.toi.presentertekandidater.log
-import no.nav.arbeidsgiver.toi.presentertekandidater.secureLog
 import no.nav.arbeidsgiver.toi.presentertekandidater.sikkerhet.TokendingsKlient
 import no.nav.arbeidsgiver.toi.presentertekandidater.variable
 import java.time.Duration
@@ -53,7 +53,7 @@ class AltinnKlient(
             }
         } catch (e: AltinnrettigheterProxyKlientException) {
             log.error("Kall mot AltinnProxy med filtrering på enkeltrettighet rekruttering feilet. Se SecureLog for stacktrace.")
-            secureLog.error("Kall mot AltinnProxy med filtrering på enkeltrettighet rekruttering feilet.", e)
+            secure(log).error("Kall mot AltinnProxy med filtrering på enkeltrettighet rekruttering feilet.", e)
             throw e
         }
     }
@@ -79,7 +79,7 @@ class AltinnKlient(
             }
         } catch (e: AltinnrettigheterProxyKlientException) {
             log.error("Kall mot AltinnProxy uten filtrering på enkeltrettighet feilet. Se SecureLog for stacktrace.")
-            secureLog.error("Kall mot AltinnProxy uten filtrering på enkeltrettighet feilet", e)
+            secure(log).error("Kall mot AltinnProxy uten filtrering på enkeltrettighet feilet", e)
             throw e
         }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
@@ -17,6 +17,7 @@ import no.nav.arbeidsgiver.toi.presentertekandidater.opensearch.OpenSearchKlient
 import no.nav.arbeidsgiver.toi.presentertekandidater.samtykke.SamtykkeRepository
 import no.nav.arbeidsgiver.toi.presentertekandidater.sikkerhet.Rolle
 import no.nav.arbeidsgiver.toi.presentertekandidater.visningkontaktinfo.VisningKontaktinfoRepository
+import no.nav.helse.rapids_rivers.toUUID
 import org.slf4j.Logger
 import java.util.*
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
@@ -18,9 +18,10 @@ import no.nav.arbeidsgiver.toi.presentertekandidater.samtykke.SamtykkeRepository
 import no.nav.arbeidsgiver.toi.presentertekandidater.sikkerhet.Rolle
 import no.nav.arbeidsgiver.toi.presentertekandidater.visningkontaktinfo.VisningKontaktinfoRepository
 import no.nav.helse.rapids_rivers.toUUID
+import org.slf4j.Logger
 import java.util.*
 
-private val log = log("no.nav.arbeidsgiver.toi.presentertekandidater.controller.kt")
+val log: Logger = log("no.nav.arbeidsgiver.toi.presentertekandidater.controller.kt")
 
 fun startController(
     javalin: Javalin,

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
@@ -7,7 +7,11 @@ import io.javalin.http.Context
 import io.javalin.http.ForbiddenResponse
 import io.javalin.http.InternalServerErrorResponse
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee
-import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.*
+import no.nav.arbeidsgiver.toi.presentertekandidater.SecureLogLogger.Companion.secure
+import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.Kandidat
+import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.Kandidatliste
+import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.KandidatlisteMedAntallKandidater
+import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.KandidatlisteRepository
 import no.nav.arbeidsgiver.toi.presentertekandidater.opensearch.Cv
 import no.nav.arbeidsgiver.toi.presentertekandidater.opensearch.OpenSearchKlient
 import no.nav.arbeidsgiver.toi.presentertekandidater.samtykke.SamtykkeRepository
@@ -16,7 +20,7 @@ import no.nav.arbeidsgiver.toi.presentertekandidater.visningkontaktinfo.VisningK
 import no.nav.helse.rapids_rivers.toUUID
 import java.util.*
 
-private val logger = log("controller")
+private val log = log("no.nav.arbeidsgiver.toi.presentertekandidater.controller.kt")
 
 fun startController(
     javalin: Javalin,
@@ -47,19 +51,23 @@ fun startController(
             Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING
         )
         delete("/kandidat/{uuid}", slettKandidat(kandidatlisteRepository), Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING)
-        post("/kandidat/{uuid}/registrerviskontaktinfo", registrerVisningAvKontaktInfo(kandidatlisteRepository, visningKontaktinfoRepository), Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING)
+        post(
+            "/kandidat/{uuid}/registrerviskontaktinfo",
+            registrerVisningAvKontaktInfo(kandidatlisteRepository, visningKontaktinfoRepository),
+            Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING
+        )
         get(
             "/ekstern/antallkandidater",
             hentAntallKandidater(kandidatlisteRepository),
             Rolle.EKSTERN_ARBEIDSGIVER
         )
     }.exception(IllegalArgumentException::class.java) { e, ctx ->
-        logger.warn("Kall mot ${ctx.path()} feiler på grunn av ugyldig input. Se SecureLog for stacktrace.")
-        secureLog.warn("Kall mot ${ctx.path()} feiler på grunn av ugyldig input.", e)
+        log.warn("Kall mot ${ctx.path()} feiler på grunn av ugyldig input. Se SecureLog for stacktrace.")
+        secure(log).warn("Kall mot ${ctx.path()} feiler på grunn av ugyldig input.", e)
         ctx.status(400)
     }.exception(Exception::class.java) { e, ctx ->
-        logger.error("Kall mot ${ctx.path()} førte til en ukjent feil. Se SecureLog for stacktrace.")
-        secureLog.error("Kall mot ${ctx.path()} førte til en ukjent feil.", e)
+        log.error("Kall mot ${ctx.path()} førte til en ukjent feil. Se SecureLog for stacktrace.")
+        secure(log).error("Kall mot ${ctx.path()} førte til en ukjent feil.", e)
         ctx.status(500)
     }
 }
@@ -69,14 +77,15 @@ private val registrerVisningAvKontaktInfo: (KandidatlisteRepository, VisningKont
         { context ->
             val kandidatUuid = UUID.fromString(context.pathParam("uuid"))
             val kandidat = kandidatlisteRepository.hentKandidatMedUUID(kandidatUuid) ?: throw BadRequestResponse()
-            val kandidatliste = kandidatlisteRepository.hentKandidatlisteTilKandidat(kandidatUuid) ?: throw InternalServerErrorResponse()
+            val kandidatliste = kandidatlisteRepository.hentKandidatlisteTilKandidat(kandidatUuid)
+                ?: throw InternalServerErrorResponse()
             val lagringGikkBra = try {
                 visningKontakInfoRepository.registrerVisning(kandidat.aktørId, kandidatliste.stillingId)
             } catch (e: Exception) {
                 false
             }
-            if(!lagringGikkBra) {
-                logger.error("Fikk ikke til å lagre visning av kontakinfo med kandidatuuid: $kandidatUuid")
+            if (!lagringGikkBra) {
+                log.error("Fikk ikke til å lagre visning av kontakinfo med kandidatuuid: $kandidatUuid")
             }
             context.status(200)
         }
@@ -113,6 +122,7 @@ private val hentSamtykkeGammel: (samtykkeRepository: SamtykkeRepository) -> (Con
 private val hentSamtykke: (samtykkeRepository: SamtykkeRepository) -> (Context) -> Unit = { samtykkeRepository ->
     { context ->
         data class Respons(val harSamtykket: Boolean)
+
         val fødselsnummer = context.hentFødselsnummer()
         val harSamtykket = samtykkeRepository.harSamtykket(fødselsnummer)
         context.json(Respons(harSamtykket))
@@ -120,7 +130,7 @@ private val hentSamtykke: (samtykkeRepository: SamtykkeRepository) -> (Context) 
     }
 }
 
-    private val lagreSamtykke: (samtykkeRepository: SamtykkeRepository) -> (Context) -> Unit = { samtykkeRepository ->
+private val lagreSamtykke: (samtykkeRepository: SamtykkeRepository) -> (Context) -> Unit = { samtykkeRepository ->
     { context ->
         val fødselsnummer = context.hentFødselsnummer()
 
@@ -190,7 +200,7 @@ private val hentKandidatlisteVurderinger: (kandidatlisteRepository: Kandidatlist
             val stillingId: String = context.pathParam("stillingId")
             val kandidatlisteId = repository.hentKandidatliste(stillingId.toUUID())?.id
             context.json(
-                if(kandidatlisteId==null) emptyList()
+                if (kandidatlisteId == null) emptyList()
                 else repository.hentKandidater(kandidatlisteId).map {
                     object {
                         val aktørId = it.aktørId
@@ -207,10 +217,8 @@ private val hentAntallKandidater: (kandidatlisteRepository: KandidatlisteReposit
             log("hentKandidaterForArbeidsgiver").info("Henter kandidater for arbeidsgiver.")
             val virksomhetsnummer = context.queryParam("virksomhetsnummer") ?: throw BadRequestResponse()
             context.validerRekruttererRolleIOrganisasjon(virksomhetsnummer)
-            val antallKandidater = repository.hentKandidatlisterSomIkkeErSlettetMedAntall(virksomhetsnummer).map {
-                it.antallKandidater
-            }.sum()
-
+            val antallKandidater =
+                repository.hentKandidatlisterSomIkkeErSlettetMedAntall(virksomhetsnummer).sumOf { it.antallKandidater }
             context.json(
                 object {
                     val antallKandidater = antallKandidater
@@ -257,8 +265,8 @@ fun Context.validerRekruttererRolleIOrganisasjon(virksomhetsnummer: String) {
     val representererVirksomhet =
         virksomhetsnummer in this.setOrganisasjonerForRekruttering().map { it.organizationNumber }
     if (!representererVirksomhet) {
-        log.info("Bruker har ikke enkeltrettighet Rekruttering for angitt virksomhet. Se virksomhetsnummer i SecureLog")
-        secureLog.info("Bruker har ikke enkeltrettighet Rekruttering for virksomheten ${virksomhetsnummer}")
+        this@validerRekruttererRolleIOrganisasjon.log.info("Bruker har ikke enkeltrettighet Rekruttering for angitt virksomhet. Se virksomhetsnummer i SecureLog")
+        secure(this@validerRekruttererRolleIOrganisasjon.log).info("Bruker har ikke enkeltrettighet Rekruttering for virksomheten ${virksomhetsnummer}")
         throw ForbiddenResponse("Bruker har ikke enkeltrettighet Rekruttering for angitt virksomhet")
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
@@ -18,6 +18,7 @@ import no.nav.arbeidsgiver.toi.presentertekandidater.opensearch.OpenSearchKlient
 import no.nav.arbeidsgiver.toi.presentertekandidater.samtykke.SamtykkeRepository
 import no.nav.arbeidsgiver.toi.presentertekandidater.sikkerhet.Rolle
 import no.nav.arbeidsgiver.toi.presentertekandidater.visningkontaktinfo.VisningKontaktinfoRepository
+import org.slf4j.Logger
 import java.util.*
 
 val log: Logger = log("no.nav.arbeidsgiver.toi.presentertekandidater.controller.kt")

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/kandidatliste/slettejobb.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/kandidatliste/slettejobb.kt
@@ -1,14 +1,14 @@
 package no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste
 
+import no.nav.arbeidsgiver.toi.presentertekandidater.SecureLogLogger.Companion.secure
 import no.nav.arbeidsgiver.toi.presentertekandidater.log
-import no.nav.arbeidsgiver.toi.presentertekandidater.secureLog
 import java.time.ZonedDateTime
 import java.util.*
 
 private const val antallMillisekunderIMinutt = 60000L
 private const val tidTilFørsteKjøring = antallMillisekunderIMinutt
 private const val tidMellomHverKjøring = antallMillisekunderIMinutt * 60
-private val log = log("slettejobb.kt")
+private val log = log("no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.slettejobb.kt")
 
 fun startPeriodiskSlettingAvKandidaterOgKandidatlister(repository: KandidatlisteRepository) {
     val jobb = object : TimerTask() {
@@ -34,7 +34,7 @@ private fun slettKandidater(repository: KandidatlisteRepository) {
     kandidater.forEach { kandidat ->
         repository.slettKandidat(kandidat.id!!)
         log.info("Slettet kandidat fra kandidatliste med kandidatlisteId ${kandidat.kandidatlisteId} på grunn av periodisk sletteregel. Se SecureLog for aktørId.")
-        secureLog.info("Slettet kandidat med aktørId ${kandidat.aktørId} fra kandidatliste med kandidatlisteId ${kandidat.kandidatlisteId} pga. sletteregel")
+        secure(log).info("Slettet kandidat med aktørId ${kandidat.aktørId} fra kandidatliste med kandidatlisteId ${kandidat.kandidatlisteId} pga. sletteregel")
     }
 }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/utils.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/utils.kt
@@ -2,14 +2,91 @@ package no.nav.arbeidsgiver.toi.presentertekandidater
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.lang.Exception
+import org.slf4j.Marker
+import org.slf4j.MarkerFactory
 
 val Any.log: Logger
     get() = LoggerFactory.getLogger(this::class.java)
 
 fun log(name: String): Logger = LoggerFactory.getLogger(name)
 
-val secureLog: Logger = LoggerFactory.getLogger("secureLog")
+/**
+ * Styrer logging til [secureLog](https://doc.nais.io/observability/logs/#secure-logs), forutsatt riktig konfigurasjon av Logback.
+ *
+ * Brukes ved å dekorere en hvilken som helst, vanlig org.slf4j.Logger slik:
+ * ```
+ * import no.nav.statistikkapi.logging.SecureLogLogger.Companion.secure
+ * ...
+ * secure(log).info(msg)
+ * ```
+ *
+ * For at dette skal virke må appens fil `logback.xml` bruke appendere med filtere slik at logging events som har en marker med navn `SECURE_LOG` styres til riktig loggfil:
+ * ```
+ * <configuration>
+ *     <appender name="appLog" ...>
+ *         ...
+ *         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+ *             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+ *                 <marker>SECURE_LOG</marker>
+ *             </evaluator>
+ *             <OnMismatch>NEUTRAL</OnMismatch>
+ *             <OnMatch>DENY</OnMatch>
+ *         </filter>
+ *     </appender>
+ *
+ *     <appender name="secureLog" ...>
+ *         ...
+ *         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+ *             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+ *                 <marker>SECURE_LOG</marker>
+ *             </evaluator>
+ *             <OnMismatch>DENY</OnMismatch>
+ *             <OnMatch>NEUTRAL</OnMatch>
+ *         </filter>
+ *     </appender>
+ *
+ *     <root ...>
+ *         <appender-ref ref="appLog"/>
+ *         <appender-ref ref="secureLog"/>
+ *     </root>
+ * </configuration>
+ * ```
+ * Se [offisiell Logback-dokumentasjon](https://logback.qos.ch/manual/filters.html#evaluatorFilter)
+ *
+ */
+class SecureLogLogger private constructor(private val l: Logger) {
+
+    val markerName: String = "SECURE_LOG"
+
+    private val m: Marker = MarkerFactory.getMarker(markerName)
+
+    fun info(msg: String) {
+        l.info(m, msg)
+    }
+
+    fun info(msg: String, t: Throwable) {
+        l.info(m, msg, t)
+    }
+
+    fun warn(msg: String) {
+        l.warn(m, msg)
+    }
+
+    fun warn(msg: String, t: Throwable) {
+        l.warn(m, msg, t)
+    }
+
+    fun error(msg: String) {
+        l.error(m, msg)
+    }
+
+    fun error(msg: String, t: Throwable) {
+        l.error(m, msg, t)
+    }
+
+    companion object {
+        fun secure(l: Logger): SecureLogLogger = SecureLogLogger(l)
+    }
+}
 
 fun Map<String, String>.variable(felt: String) = this[felt] ?: error("$felt er ikke angitt")
-

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <configuration>
-    <appender name="loggIJsonFormatTilKibana" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="appLog" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>SECURE_LOG</marker>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
     </appender>
 
     <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -14,13 +21,17 @@
             <maxFileSize>128MB</maxFileSize>
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>SECURE_LOG</marker>
+            </evaluator>
+            <OnMismatch>DENY</OnMismatch>
+            <OnMatch>NEUTRAL</OnMatch>
+        </filter>
     </appender>
 
-    <logger name="secureLog" level="TRACE" additivity="false">
-        <appender-ref ref="secureLog"/>
-    </logger>
-
     <root level="INFO">
-        <appender-ref ref="loggIJsonFormatTilKibana"/>
+        <appender-ref ref="appLog"/>
+        <appender-ref ref="secureLog"/>
     </root>
 </configuration>

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
@@ -5,7 +5,6 @@ import ch.qos.logback.core.read.ListAppender
 import no.nav.arbeidsgiver.toi.presentertekandidater.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
-import org.slf4j.LoggerFactory
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -36,8 +35,8 @@ class RegistrerVisningTest {
     private fun setUpLogWatcher() {
         logWatcher = ListAppender<ILoggingEvent>()
         logWatcher.start()
-        val logger =
-            LoggerFactory.getLogger("controller") as ch.qos.logback.classic.Logger
+        val logger: ch.qos.logback.classic.Logger =
+            no.nav.arbeidsgiver.toi.presentertekandidater.log as ch.qos.logback.classic.Logger
         logger.addAppender(logWatcher)
     }
 
@@ -52,10 +51,11 @@ class RegistrerVisningTest {
         lagreSamtykke(fødselsnummer)
         val accessToken = hentToken(fødselsnummer)
 
-        val request = HttpRequest.newBuilder(URI("http://localhost:9000/kandidat/${kandidat.uuid}/registrerviskontaktinfo"))
-            .header("Authorization", "Bearer $accessToken")
-            .POST(HttpRequest.BodyPublishers.noBody())
-            .build()
+        val request =
+            HttpRequest.newBuilder(URI("http://localhost:9000/kandidat/${kandidat.uuid}/registrerviskontaktinfo"))
+                .header("Authorization", "Bearer $accessToken")
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build()
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
 
         assertThat(response.statusCode()).isEqualTo(200)
@@ -74,10 +74,11 @@ class RegistrerVisningTest {
         lagreSamtykke(fødselsnummer)
         val accessToken = hentToken(fødselsnummer)
 
-        val request = HttpRequest.newBuilder(URI("http://localhost:9000/kandidat/${UUID.randomUUID()}/registrerviskontaktinfo"))
-            .header("Authorization", "Bearer $accessToken")
-            .POST(HttpRequest.BodyPublishers.noBody())
-            .build()
+        val request =
+            HttpRequest.newBuilder(URI("http://localhost:9000/kandidat/${UUID.randomUUID()}/registrerviskontaktinfo"))
+                .header("Authorization", "Bearer $accessToken")
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build()
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
 
         assertThat(response.statusCode()).isEqualTo(400)
@@ -86,7 +87,8 @@ class RegistrerVisningTest {
     @Test
     fun `Skal returnere 200 selv om registrering av visning feiler`() {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
-        val kandidat = kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!, aktørId = "987"))
+        val kandidat =
+            kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!, aktørId = "987"))
         val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", kandidatliste.virksomhetsnummer))
 
 
@@ -97,10 +99,11 @@ class RegistrerVisningTest {
             lagreSamtykke(fødselsnummer)
             val accessToken = hentToken(fødselsnummer)
 
-            val request = HttpRequest.newBuilder(URI("http://localhost:9000/kandidat/${kandidat.uuid}/registrerviskontaktinfo"))
-                .header("Authorization", "Bearer $accessToken")
-                .POST(HttpRequest.BodyPublishers.noBody())
-                .build()
+            val request =
+                HttpRequest.newBuilder(URI("http://localhost:9000/kandidat/${kandidat.uuid}/registrerviskontaktinfo"))
+                    .header("Authorization", "Bearer $accessToken")
+                    .POST(HttpRequest.BodyPublishers.noBody())
+                    .build()
             val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
 
             assertThat(response.statusCode()).isEqualTo(200)
@@ -109,8 +112,7 @@ class RegistrerVisningTest {
             assertThat(logWatcher.list[logWatcher.list.size - 1].message).contains("Fikk ikke til å lagre visning av kontakinfo med kandidatuuid: ${kandidat.uuid}")
         } catch (e: Exception) {
             fail(e)
-        }
-        finally {
+        } finally {
             renameDatabaseTabell("feil", "visning_kontaktinfo")
         }
     }
@@ -126,10 +128,11 @@ class RegistrerVisningTest {
         lagreSamtykke(fødselsnummer)
         val accessToken = hentToken(fødselsnummer)
 
-        val request = HttpRequest.newBuilder(URI("http://localhost:9000/kandidat/${kandidat.uuid}/registrerviskontaktinfo"))
-            .header("Authorization", "Bearer $accessToken")
-            .POST(HttpRequest.BodyPublishers.noBody())
-            .build()
+        val request =
+            HttpRequest.newBuilder(URI("http://localhost:9000/kandidat/${kandidat.uuid}/registrerviskontaktinfo"))
+                .header("Authorization", "Bearer $accessToken")
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build()
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
 
         assertThat(response.statusCode()).isEqualTo(200)


### PR DESCRIPTION
forsøk på å fikse at noen loggposter som skulle til Securelogs havner i apploggen istedenfor, pluss ny måte bevarer logger-navnet i loggen; feltet "component" kan vise klassenavnet på den loggende klassen

https://trello.com/c/Lk1CC31x