### PR TITLE
Altinn3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ jobs:
     uses: navikt/toi-github-actions-workflows/.github/workflows/build-and-deploy.yaml@v1
     with:
       java-version: '21'
-      deploy-to-dev-if-branch-name-is: 'logback-dockerfile'
+      deploy-to-dev-if-branch-name-is: 'altinn3'
     permissions:
       contents: read
       id-token: write

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.1")
     testImplementation("org.assertj:assertj-core:3.23.1")
+    testImplementation("org.mockito:mockito-core:5.20.0")
     testImplementation("no.nav.security:mock-oauth2-server:0.5.6")
     testImplementation("org.testcontainers:testcontainers:1.17.5")
     testImplementation("org.testcontainers:postgresql:1.17.5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,8 +54,6 @@ dependencies {
     implementation("org.apache.kafka:kafka-clients:3.9.0")
     implementation("com.github.navikt:rapids-and-rivers:2023041310341681374880.67ced5ad4dda")
 
-    implementation("no.nav.arbeidsgiver:altinn-rettigheter-proxy-klient:3.1.0")
-
     implementation("no.nav.security:token-client-core:2.1.0")
 
     testImplementation(kotlin("test"))

--- a/logback.xml
+++ b/logback.xml
@@ -6,27 +6,24 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
-                <marker>SECURE_LOG</marker>
+                <marker>TEAM_LOGS</marker>
             </evaluator>
             <OnMismatch>NEUTRAL</OnMismatch>
             <OnMatch>DENY</OnMatch>
         </filter>
     </appender>
 
-    <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/secure-logs/secure.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>1</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>128MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    <appender name="team-logs" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>team-logs.nais-system:5170</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>
+                {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}
+            </customFields>
+            <includeContext>false</includeContext>
+        </encoder>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
-                <marker>SECURE_LOG</marker>
+                <marker>TEAM_LOGS</marker>
             </evaluator>
             <OnMismatch>DENY</OnMismatch>
             <OnMatch>NEUTRAL</OnMatch>
@@ -35,6 +32,10 @@
 
     <root level="INFO">
         <appender-ref ref="appLog"/>
-        <appender-ref ref="secureLog"/>
+        <appender-ref ref="team-logs"/>
     </root>
+
+    <logger name="team-logs-logger" level="INFO" additivity="false">
+        <appender-ref ref="team-logs" />
+    </logger>
 </configuration>

--- a/logback.xml
+++ b/logback.xml
@@ -8,8 +8,8 @@
             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
                 <marker>TEAM_LOGS</marker>
             </evaluator>
-            <OnMismatch>NEUTRAL</OnMismatch>
             <OnMatch>DENY</OnMatch>
+            <OnMismatch>ACCEPT</OnMismatch>
         </filter>
     </appender>
 
@@ -25,8 +25,8 @@
             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
                 <marker>TEAM_LOGS</marker>
             </evaluator>
+            <OnMatch>ACCEPT</OnMatch>
             <OnMismatch>DENY</OnMismatch>
-            <OnMatch>NEUTRAL</OnMatch>
         </filter>
     </appender>
 

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -7,7 +7,6 @@
     "min_replicas": 1,
     "max_replicas": 1,
     "requested_cpu": "50m",
-    "altinn_proxy_url": "http://arbeidsgiver-altinn-tilganger.fager",
     "altinn_proxy_audience": "dev-gcp:fager:arbeidsgiver-altinn-tilganger",
     "adGruppeArbeidsgiverrettet": "52bc2af7-38d1-468b-b68d-0f3a4de45af2",
     "adGruppeUtvikler": "a1749d9a-52e0-4116-bb9f-935c38f6c74a"

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -7,8 +7,8 @@
     "min_replicas": 1,
     "max_replicas": 1,
     "requested_cpu": "50m",
-    "altinn_proxy_url": "http://altinn-rettigheter-proxy.arbeidsgiver/altinn-rettigheter-proxy",
-    "altinn_proxy_audience": "dev-gcp:arbeidsgiver:altinn-rettigheter-proxy",
+    "altinn_proxy_url": "http://arbeidsgiver-altinn-tilganger.fager",
+    "altinn_proxy_audience": "dev-gcp:fager:arbeidsgiver-altinn-tilganger",
     "adGruppeArbeidsgiverrettet": "52bc2af7-38d1-468b-b68d-0f3a4de45af2",
     "adGruppeUtvikler": "a1749d9a-52e0-4116-bb9f-935c38f6c74a"
 }

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -76,7 +76,7 @@ spec:
     - name: KAFKA_RESET_POLICY
       value: "latest"
     - name: ALTINN_PROXY_URL
-      value: {{ altinn_proxy_url }}
+      value: http://arbeidsgiver-altinn-tilganger.fager/altinn-tilganger
     - name: ALTINN_PROXY_AUDIENCE
       value: {{ altinn_proxy_audience }}
   observability:

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -57,8 +57,8 @@ spec:
         - application: rekrutteringsbistand
     outbound:
       rules:
-        - application: altinn-rettigheter-proxy
-          namespace: arbeidsgiver
+        - application: arbeidsgiver-altinn-tilganger
+          namespace: fager
   kafka:
     pool: {{ kafka-pool }}
   gcp:

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -31,8 +31,6 @@ spec:
     requests:
       cpu: {{ requested_cpu }}
       memory: 512Mi
-  secureLogs:
-    enabled: true
   openSearch:
     access: read
     instance: toi-kandidat
@@ -59,6 +57,8 @@ spec:
       rules:
         - application: arbeidsgiver-altinn-tilganger
           namespace: fager
+        - application: logging
+          namespace: nais-system
   kafka:
     pool: {{ kafka-pool }}
   gcp:

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -7,8 +7,8 @@
     "min_replicas": 2,
     "max_replicas": 4,
     "requested_cpu": "100m",
-    "altinn_proxy_url": "http://altinn-rettigheter-proxy.arbeidsgiver/altinn-rettigheter-proxy",
-    "altinn_proxy_audience": "prod-gcp:arbeidsgiver:altinn-rettigheter-proxy",
+    "altinn_proxy_url": "http://arbeidsgiver-altinn-tilganger.fager",
+    "altinn_proxy_audience": "prod-gcp:fager:arbeidsgiver-altinn-tilganger",
     "adGruppeArbeidsgiverrettet": "46c8e3b2-0469-4740-983f-d8cd2b6e4fee",
     "adGruppeUtvikler": "41080368-439f-4128-858a-afbef876431e"
 }

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -7,7 +7,6 @@
     "min_replicas": 2,
     "max_replicas": 4,
     "requested_cpu": "100m",
-    "altinn_proxy_url": "http://arbeidsgiver-altinn-tilganger.fager",
     "altinn_proxy_audience": "prod-gcp:fager:arbeidsgiver-altinn-tilganger",
     "adGruppeArbeidsgiverrettet": "46c8e3b2-0469-4740-983f-d8cd2b6e4fee",
     "adGruppeUtvikler": "41080368-439f-4128-858a-afbef876431e"

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnException.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnException.kt
@@ -1,0 +1,7 @@
+package no.nav.arbeidsgiver.toi.presentertekandidater.altinn;
+
+class AltinnException : RuntimeException {
+    constructor(message: String) : super(message)
+
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnException.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnException.kt
@@ -1,7 +1,13 @@
 package no.nav.arbeidsgiver.toi.presentertekandidater.altinn;
 
-class AltinnException : RuntimeException {
-    constructor(message: String) : super(message)
+sealed class AltinnException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
-    constructor(message: String, cause: Throwable) : super(message, cause)
+class AltinnTilgangException : AltinnException {
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable?) : super(message, cause)
+}
+
+class AltinnServiceException : AltinnException {
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable?) : super(message, cause)
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnException.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnException.kt
@@ -1,4 +1,4 @@
-package no.nav.arbeidsgiver.toi.presentertekandidater.altinn;
+package no.nav.arbeidsgiver.toi.presentertekandidater.altinn
 
 sealed class AltinnException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -142,17 +142,12 @@ class AltinnKlient(
                 }
             } catch (e: InterruptedException) {
                 sisteException = e
-                log.warn(
-                    "Nettverksfeil ved kall mot Altinn: ${e.message}, prøver igjen (forsøk $forsøk av $maksForsøk)",
-                    e
-                )
+                log.error("Avbrutt ved kall til Altinn: ${e.message}", e)
                 Thread.currentThread().interrupt()
+                break
             } catch (e: IOException) {
                 sisteException = e
-                log.warn(
-                    "Nettverksfeil ved kall mot Altinn: ${e.message}, prøver igjen (forsøk $forsøk av $maksForsøk)",
-                    e
-                )
+                log.warn("Nettverksfeil ved kall mot Altinn: ${e.message}, prøver igjen (forsøk $forsøk av $maksForsøk)", e)
             }
             if (forsøk < maksForsøk) {
                 Thread.sleep(500L) // Vent litt før nytt forsøk

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -45,7 +45,14 @@ class AltinnKlient(
         val exchangeToken = tokendingsKlient.veksleInnToken(accessToken, scope)
 
         val altinnTilganger = hentAltinnTilganger(exchangeToken, altinn2Tilganger, altinn3Tilganger)
+
+        // Forsikre at vi kun inkluderer organisasjoner hvor brukeren har riktig rettighet
+        val orgnrMedTilgang = altinnTilganger.tilgangTilOrgNr.filter { tilgang ->
+            tilgang.key in altinn2Tilganger || tilgang.key in altinn3Tilganger
+        }.values.flatten().toSet()
+
         val organisasjoner = mapAltinnTilgangTilAltinnReportee(altinnTilganger, kunUnderenheter = true)
+            .filter { orgnrMedTilgang.contains(it.organizationNumber) }
 
         return organisasjoner.also {
             if (it.isEmpty()) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -102,7 +102,7 @@ class AltinnKlient(
             secure(log).warn(
                 "Mottok ${response.statusCode()}-respons fra arbeidsgiver-altinn-tilganger: ${response.body()}"
             )
-            throw IllegalStateException("Klarte ikke hente Altinn-tilganger, statuskode: ${response.statusCode()}")
+            throw AltinnServiceException("Klarte ikke hente Altinn-tilganger, statuskode: ${response.statusCode()}")
         }
 
         val altinnTilganger: AltinnTilgangerResponse = mapper.readValue(response.body())
@@ -132,7 +132,7 @@ class AltinnKlient(
                     log.warn("Mottok ${respons.statusCode()} statuskode fra Altinn, prøver igjen (forsøk $forsøk av $maksForsøk)")
                 } else if (altinnIsError) {
                     log.warn("Mottok isError=true og tom tilgangsliste fra Altinn, prøver igjen (forsøk $forsøk av $maksForsøk)")
-                    sisteException = AltinnException("Mottok isError=true og tom tilgangsliste")
+                    sisteException = AltinnTilgangException("Mottok isError=true og tom tilgangsliste")
                 } else {
                     return respons.also {
                         if (forsøk > 1) {
@@ -160,7 +160,7 @@ class AltinnKlient(
         }
         log.error("Klarte ikke hente Altinn-tilganger etter $maksForsøk forsøk")
         if (sisteException is AltinnException) throw sisteException
-        else throw IllegalStateException("Klarte ikke hente Altinn-tilganger", sisteException)
+        else throw AltinnServiceException("Klarte ikke hente Altinn-tilganger", sisteException)
     }
 
     /**

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -184,6 +184,10 @@ class AltinnKlient(
 
         return altinnTilganger.hierarki.flatMap { flatUtHierarki(it) }
     }
+
+    fun tømCache() {
+        cache.tømCache()
+    }
 }
 
 data class AltinnTilgangRequest(

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -37,7 +37,7 @@ class AltinnKlient(
     private val cache = Cache(levetid = cacheLevetid)
 
     fun hentOrganisasjonerMedRettighetKandidaterFraAltinn(fnr: String, accessToken: String): List<AltinnReportee> {
-        log.info("Skal hente organisasjoner hvor innlogget person har rettighet nav_rekruttering_kandidater")
+        log.info("Skal hente organisasjoner hvor innlogget person har rettighet nav_rekruttering_kandidater eller Rekruttering (5078:1)")
 
         val cachetOrganisasjoner = cache.hentFraCache(fnr, NAV_REKRUTTERING_KANDIDATER)
         if (cachetOrganisasjoner != null) return cachetOrganisasjoner
@@ -141,9 +141,9 @@ class AltinnKlient(
                 val altinnIsError = altinnTilganger?.isError == true && altinnTilganger.hierarki.isEmpty()
 
                 if (respons.statusCode() in 500..504) {
-                    log.warn("Mottok ${respons.statusCode()} statuskode fra Altinn, prøver igjen (forsøk $forsøk av $maksForsøk)")
+                    log.info("Mottok ${respons.statusCode()} statuskode fra Altinn, prøver igjen (forsøk $forsøk av $maksForsøk)")
                 } else if (altinnIsError) {
-                    log.warn("Mottok isError=true og tom tilgangsliste fra Altinn, prøver igjen (forsøk $forsøk av $maksForsøk)")
+                    log.info("Mottok isError=true og tom tilgangsliste fra Altinn, prøver igjen (forsøk $forsøk av $maksForsøk)")
                     sisteException = AltinnTilgangException("Mottok isError=true og tom tilgangsliste")
                 } else {
                     return respons.also {

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -31,7 +31,7 @@ class AltinnKlient(
 
     private val altinnProxyUrl = envs.variable("ALTINN_PROXY_URL")
     private val scope = envs.variable("ALTINN_PROXY_AUDIENCE")
-    private val altinn2Tilganger = emptyList<String>()
+    private val altinn2Tilganger = listOf("5078:1")
     private val altinn3Tilganger = listOf("nav_rekruttering_kandidater")
     private val cacheLevetid = Duration.ofMinutes(15)
     private val cache = Cache(levetid = cacheLevetid)

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.javalin.http.HttpCode
 import no.nav.arbeidsgiver.toi.presentertekandidater.SecureLogLogger.Companion.secure
-import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.ENKELTRETTIGHET_REKRUTTERING
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.NAV_REKRUTTERING_KANDIDATER
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.INGEN
 import no.nav.arbeidsgiver.toi.presentertekandidater.log
 import no.nav.arbeidsgiver.toi.presentertekandidater.sikkerhet.TokendingsKlient
@@ -36,10 +36,10 @@ class AltinnKlient(
     private val cacheLevetid = Duration.ofMinutes(15)
     private val cache = Cache(levetid = cacheLevetid)
 
-    fun hentOrganisasjonerMedRettighetRekrutteringFraAltinn(fnr: String, accessToken: String): List<AltinnReportee> {
-        log.info("Skal hente organisasjoner hvor innlogget person har rekrutteringsrettighet")
+    fun hentOrganisasjonerMedRettighetKandidaterFraAltinn(fnr: String, accessToken: String): List<AltinnReportee> {
+        log.info("Skal hente organisasjoner hvor innlogget person har rettighet nav_rekruttering_kandidater")
 
-        val cachetOrganisasjoner = cache.hentFraCache(fnr, ENKELTRETTIGHET_REKRUTTERING)
+        val cachetOrganisasjoner = cache.hentFraCache(fnr, NAV_REKRUTTERING_KANDIDATER)
         if (cachetOrganisasjoner != null) return cachetOrganisasjoner
 
         val exchangeToken = tokendingsKlient.veksleInnToken(accessToken, scope)
@@ -58,11 +58,11 @@ class AltinnKlient(
             if (it.isEmpty()) {
                 //TODO: Rydd i loggmeldingene etter testing
 //                log.info("Innlogget person representerer ingen organisasjoner")
-                secure(log).info("Innlogget person (fnr=$fnr) representerer ingen organisasjoner med rekrutteringsrettighet")
+                secure(log).info("Innlogget person (fnr=$fnr) representerer ingen organisasjoner med rettighet nav_rekruttering_kandidater")
             } else {
 //                log.info("Innlogget person representerer ${it.size} organisasjoner")
-                secure(log).info("Innlogget person (fnr=$fnr) representerer ${it.size} organisasjoner med rekrutteringsrettighet (${it.joinToString { it.organizationNumber }})")
-                cache.leggICache(fnr, it, ENKELTRETTIGHET_REKRUTTERING)
+                secure(log).info("Innlogget person (fnr=$fnr) representerer ${it.size} organisasjoner med rettighet nav_rekruttering_kandidater (${it.joinToString { it.organizationNumber }})")
+                cache.leggICache(fnr, it, NAV_REKRUTTERING_KANDIDATER)
             }
         }
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -31,8 +31,8 @@ class AltinnKlient(
 
     private val altinnProxyUrl = envs.variable("ALTINN_PROXY_URL")
     private val scope = envs.variable("ALTINN_PROXY_AUDIENCE")
-    private val altinn2Tilganger = listOf("5078:1") // Rekrutteringsrettighet Altinn2. TODO: Erstattes av altinn3-rettighet
-    private val altinn3Tilganger = emptyList<String>() // TODO: Legg til Altinn3-rettighet når den er klar
+    private val altinn2Tilganger = emptyList<String>()
+    private val altinn3Tilganger = listOf("nav_rekruttering_kandidater")
     private val cacheLevetid = Duration.ofMinutes(15)
     private val cache = Cache(levetid = cacheLevetid)
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -56,12 +56,10 @@ class AltinnKlient(
 
         return organisasjoner.also {
             if (it.isEmpty()) {
-                //TODO: Rydd i loggmeldingene etter testing
-//                log.info("Innlogget person representerer ingen organisasjoner")
-                secure(log).info("Innlogget person (fnr=$fnr) representerer ingen organisasjoner med rettighet nav_rekruttering_kandidater")
+                log.info("Innlogget person representerer ingen organisasjoner med rettighet nav_rekruttering_kandidater eller Rekruttering (5078:1)")
             } else {
-//                log.info("Innlogget person representerer ${it.size} organisasjoner")
-                secure(log).info("Innlogget person (fnr=$fnr) representerer ${it.size} organisasjoner med rettighet nav_rekruttering_kandidater (${it.joinToString { it.organizationNumber }})")
+                log.info("Innlogget person representerer ${it.size} organisasjoner med rettighet nav_rekruttering_kandidater eller Rekruttering (5078:1)")
+                secure(log).info("Innlogget person representerer ${it.size} organisasjoner med rettighet nav_rekruttering_kandidater eller Rekruttering (5078:1). Orgnr: ${it.joinToString { it.organizationNumber }}")
                 cache.leggICache(fnr, it, NAV_REKRUTTERING_KANDIDATER)
             }
         }
@@ -80,11 +78,10 @@ class AltinnKlient(
 
         return organisasjoner.also {
             if (it.isEmpty()) {
-//                log.info("Innlogget person representerer ingen organisasjoner")
-                secure(log).info("Innlogget person (fnr=$fnr) representerer ingen organisasjoner i Altinn")
+                log.info("Innlogget person representerer ingen organisasjoner i Altinn")
             } else {
-//                log.info("Innlogget person representerer ${it.size} organisasjoner")
-                secure(log).info("Innlogget person (fnr=$fnr) representerer ${it.size} organisasjoner i Altinn (${it.joinToString { it.organizationNumber }})")
+                log.info("Innlogget person representerer ${it.size} organisasjoner i Altinn")
+                secure(log).info("Innlogget person representerer ${it.size} organisasjoner i Altinn. Orgnr: ${it.joinToString { it.organizationNumber }}")
                 cache.leggICache(fnr, it, INGEN)
             }
         }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -1,16 +1,20 @@
 package no.nav.arbeidsgiver.toi.presentertekandidater.altinn
 
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlient
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlientConfig
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.ProxyConfig
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.error.exceptions.AltinnrettigheterProxyKlientException
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.*
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.javalin.http.HttpCode
 import no.nav.arbeidsgiver.toi.presentertekandidater.SecureLogLogger.Companion.secure
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.ENKELTRETTIGHET_REKRUTTERING
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.INGEN
 import no.nav.arbeidsgiver.toi.presentertekandidater.log
 import no.nav.arbeidsgiver.toi.presentertekandidater.sikkerhet.TokendingsKlient
 import no.nav.arbeidsgiver.toi.presentertekandidater.variable
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.time.Duration
 
 
@@ -18,70 +22,216 @@ class AltinnKlient(
     envs: Map<String, String>,
     private val tokendingsKlient: TokendingsKlient,
 ) {
-    private val consumerId = envs.variable("NAIS_APP_NAME")
+    companion object {
+        val mapper = jacksonObjectMapper()
+        val httpKlient: HttpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build()
+    }
+
     private val altinnProxyUrl = envs.variable("ALTINN_PROXY_URL")
     private val scope = envs.variable("ALTINN_PROXY_AUDIENCE")
-    private val config = AltinnrettigheterProxyKlientConfig(ProxyConfig(consumerId, altinnProxyUrl))
-    private val klient = AltinnrettigheterProxyKlient(config)
-    private val rekrutteringsrettighetAltinnKode = "5078"
-    private val rekrutteringsrettighetAltinnServiceEdition = "1"
+    private val altinn2Tilganger = listOf("5078:1") // Rekrutteringsrettighet Altinn2. TODO: Erstattes av altinn3-rettighet
+    private val altinn3Tilganger = emptyList<String>() // TODO: Legg til Altinn3-rettighet når den er klar
     private val cacheLevetid = Duration.ofMinutes(15)
     private val cache = Cache(levetid = cacheLevetid)
 
     fun hentOrganisasjonerMedRettighetRekrutteringFraAltinn(fnr: String, accessToken: String): List<AltinnReportee> {
-        log.info("Skal hente organisasjoner for innlogget person")
+        log.info("Skal hente organisasjoner hvor innlogget person har rekrutteringsrettighet")
 
         val cachetOrganisasjoner = cache.hentFraCache(fnr, ENKELTRETTIGHET_REKRUTTERING)
         if (cachetOrganisasjoner != null) return cachetOrganisasjoner
 
         val exchangeToken = tokendingsKlient.veksleInnToken(accessToken, scope)
 
-        try {
-            return klient.hentOrganisasjoner(
-                selvbetjeningToken = SelvbetjeningToken(exchangeToken),
-                subject = Subject(fnr),
-                serviceCode = ServiceCode(rekrutteringsrettighetAltinnKode),
-                serviceEdition = ServiceEdition(rekrutteringsrettighetAltinnServiceEdition),
-                filtrerPåAktiveOrganisasjoner = true
-            ).also {
-                if (it.isEmpty()) {
-                    log.info("Innlogget person representerer ingen organisasjoner")
-                } else {
-                    log.info("Innlogget person representerer ${it.size} organisasjoner")
-                    cache.leggICache(fnr, it, ENKELTRETTIGHET_REKRUTTERING)
-                }
+        val altinnTilganger = hentAltinnTilganger(exchangeToken, altinn2Tilganger, altinn3Tilganger)
+        val organisasjoner = mapAltinnTilgangTilAltinnReportee(altinnTilganger)
+
+        return organisasjoner.also {
+            if (it.isEmpty()) {
+                log.info("Innlogget person representerer ingen organisasjoner")
+            } else {
+                log.info("Innlogget person representerer ${it.size} organisasjoner")
+                cache.leggICache(fnr, it, ENKELTRETTIGHET_REKRUTTERING)
             }
-        } catch (e: AltinnrettigheterProxyKlientException) {
-            log.error("Kall mot AltinnProxy med filtrering på enkeltrettighet rekruttering feilet. Se SecureLog for stacktrace.")
-            secure(log).error("Kall mot AltinnProxy med filtrering på enkeltrettighet rekruttering feilet.", e)
-            throw e
         }
     }
 
     fun hentOrganisasjoner(fnr: String, accessToken: String): List<AltinnReportee> {
+        log.info("Skal hente alle organisasjoner hvor innlogget person har en Altinnrettighet")
+
         val cachetOrganisasjoner = cache.hentFraCache(fnr, INGEN)
         if (cachetOrganisasjoner != null) return cachetOrganisasjoner
 
         val exchangeToken = tokendingsKlient.veksleInnToken(accessToken, scope)
 
-        try {
-            return klient.hentOrganisasjoner(
-                selvbetjeningToken = SelvbetjeningToken(exchangeToken),
-                subject = Subject(fnr),
-                filtrerPåAktiveOrganisasjoner = true
-            ).also {
-                if (it.isEmpty()) {
-                    log.info("Innlogget person representerer ingen organisasjoner")
-                } else {
-                    log.info("Innlogget person representerer ${it.size} organisasjoner")
-                    cache.leggICache(fnr, it, INGEN)
-                }
+        val altinnTilganger = hentAltinnTilganger(exchangeToken)
+        val organisasjoner = mapAltinnTilgangTilAltinnReportee(altinnTilganger)
+
+        return organisasjoner.also {
+            if (it.isEmpty()) {
+                log.info("Innlogget person representerer ingen organisasjoner")
+            } else {
+                log.info("Innlogget person representerer ${it.size} organisasjoner")
+                cache.leggICache(fnr, it, INGEN)
             }
-        } catch (e: AltinnrettigheterProxyKlientException) {
-            log.error("Kall mot AltinnProxy uten filtrering på enkeltrettighet feilet. Se SecureLog for stacktrace.")
-            secure(log).error("Kall mot AltinnProxy uten filtrering på enkeltrettighet feilet", e)
-            throw e
+        }
+    }
+
+    private fun hentAltinnTilganger(
+        token: String,
+        altinn2Tilganger: List<String> = emptyList(),
+        altinn3Tilganger: List<String> = emptyList()
+    ): AltinnTilgangerResponse {
+        val request = HttpRequest.newBuilder()
+            .uri(URI(altinnProxyUrl))
+            .header("Authorization", "Bearer $token")
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .POST(
+                HttpRequest.BodyPublishers.ofString(
+                    mapper.writeValueAsString(
+                        AltinnTilgangRequest.opprett(altinn2Tilganger, altinn3Tilganger)
+                    )
+                )
+            ).build()
+
+        val response = hentAltinnTilgangerMedRetry(httpKlient, request, maksForsøk = 3)
+
+        if (response.statusCode() != HttpCode.OK.status) {
+            secure(log).warn(
+                "Mottok ${response.statusCode()}-respons fra arbeidsgiver-altinn-tilganger: ${response.body()}"
+            )
+            throw IllegalStateException("Klarte ikke hente Altinn-tilganger, statuskode: ${response.statusCode()}")
         }
 
+        val altinnTilganger: AltinnTilgangerResponse = mapper.readValue(response.body())
+        return altinnTilganger
+    }
+
+    /**
+     * Henter Altinn-tilganger med retry-mekanisme for midlertidige 5XX-responser og nettverksfeil.
+     * I tillegg gjøres det retry dersom responsen inneholder `isError=true` og ingen tilganger.
+     *
+     * TODO: Fjern retry-mekanisme for 200-responser når arbeidsgiver-altinn-tilganger ikke lenger gjør spørringer mot Altinn2.
+     */
+    private fun hentAltinnTilgangerMedRetry(
+        httpKlient: HttpClient,
+        request: HttpRequest,
+        maksForsøk: Int
+    ): HttpResponse<String> {
+        var sisteException: Exception? = null
+        for (forsøk in 1..maksForsøk) {
+            try {
+                val respons = httpKlient.send(request, HttpResponse.BodyHandlers.ofString())
+                val altinnTilganger =
+                    if (respons.statusCode() == 200) mapper.readValue<AltinnTilgangerResponse>(respons.body()) else null
+                val altinnIsError = altinnTilganger?.isError == true && altinnTilganger.hierarki.isEmpty()
+
+                if (respons.statusCode() in 500..504) {
+                    log.warn("Mottok ${respons.statusCode()} statuskode fra Altinn, prøver igjen (forsøk $forsøk av $maksForsøk)")
+                } else if (altinnIsError) {
+                    log.warn("Mottok isError=true og tom tilgangsliste fra Altinn, prøver igjen (forsøk $forsøk av $maksForsøk)")
+                    sisteException = AltinnException("Mottok isError=true og tom tilgangsliste")
+                } else {
+                    return respons.also {
+                        if (forsøk > 1) {
+                            log.info("Hentet Altinn-tilganger etter $forsøk forsøk")
+                        }
+                    }
+                }
+            } catch (e: InterruptedException) {
+                sisteException = e
+                log.warn(
+                    "Nettverksfeil ved kall mot Altinn: ${e.message}, prøver igjen (forsøk $forsøk av $maksForsøk)",
+                    e
+                )
+                Thread.currentThread().interrupt()
+            } catch (e: IOException) {
+                sisteException = e
+                log.warn(
+                    "Nettverksfeil ved kall mot Altinn: ${e.message}, prøver igjen (forsøk $forsøk av $maksForsøk)",
+                    e
+                )
+            }
+            if (forsøk < maksForsøk) {
+                Thread.sleep(500L) // Vent litt før nytt forsøk
+            }
+        }
+        log.error("Klarte ikke hente Altinn-tilganger etter $maksForsøk forsøk")
+        if (sisteException is AltinnException) throw sisteException
+        else throw IllegalStateException("Klarte ikke hente Altinn-tilganger", sisteException)
+    }
+
+    /**
+     * Flater ut organisasjonshierarkiet fra Altinn-tilgangene til en liste av [AltinnReportee]-objekter.
+     * Bevarer relasjonen mellom underenheter og overordnet enhet ved å sette parentOrganizationNumber for underenheter.
+     *
+     * @param altinnTilganger Responsen fra arbeidsgiver-altinn-tilganger API.
+     * @return Liste av AltinnReportee-objekter som inneholder alle organisasjoner i responsen fra arbeidsgiver-altinn-tilganger API.
+     */
+    private fun mapAltinnTilgangTilAltinnReportee(altinnTilganger: AltinnTilgangerResponse): List<AltinnReportee> {
+        fun flatUtHierarki(tilgang: AltinnTilgang, parentOrgnr: String? = null): List<AltinnReportee> {
+            val nåværendeOrganisasjon = AltinnReportee(
+                name = tilgang.navn,
+                parentOrganizationNumber = parentOrgnr,
+                organizationNumber = tilgang.orgnr,
+                organizationForm = tilgang.organisasjonsform,
+            )
+            val underenheter = tilgang.underenheter.flatMap { flatUtHierarki(it, tilgang.orgnr) }
+            return listOf(nåværendeOrganisasjon) + underenheter
+        }
+
+        return altinnTilganger.hierarki.flatMap { flatUtHierarki(it) }
     }
 }
+
+data class AltinnTilgangRequest(
+    val filter: Filter
+) {
+    companion object {
+        fun opprett(
+            altinn2Tilganger: List<String> = listOf(),
+            altinn3Tilganger: List<String> = listOf()
+        ): AltinnTilgangRequest {
+            val filter = Filter(
+                altinn2Tilganger = altinn2Tilganger,
+                altinn3Tilganger = altinn3Tilganger,
+                inkluderSlettede = false
+            )
+            return AltinnTilgangRequest(filter)
+        }
+    }
+}
+
+data class Filter(
+    val altinn2Tilganger: List<String>,
+    val altinn3Tilganger: List<String>,
+    val inkluderSlettede: Boolean
+)
+
+data class AltinnTilgang(
+    val orgnr: String,
+    val altinn3Tilganger: Set<String>,
+    val altinn2Tilganger: Set<String>,
+    val underenheter: List<AltinnTilgang>,
+    val navn: String,
+    val organisasjonsform: String,
+    val erSlettet: Boolean
+)
+
+/**
+ * Respons fra arbeidsgiver-altinn-tilganger API.
+ *
+ * Responsen representerer en brukers Altinn-tilganger presentert på tre forskjellige måter:
+ * - `hierarki`: Organisasjonshierarkiet med tilganger.
+ * - `orgNrTilTilganger`: En liste over tilganger per organisasjonsnummer.
+ * - `tilgangTilOrgNr`: En liste over organisasjonsnummer per tilgang.
+ */
+data class AltinnTilgangerResponse(
+    @JsonProperty("isError")
+    val isError: Boolean,
+    val hierarki: List<AltinnTilgang>,
+    val orgNrTilTilganger: Map<String, Set<String>>,
+    val tilgangTilOrgNr: Map<String, Set<String>>
+)

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlient.kt
@@ -49,9 +49,12 @@ class AltinnKlient(
 
         return organisasjoner.also {
             if (it.isEmpty()) {
-                log.info("Innlogget person representerer ingen organisasjoner")
+                //TODO: Rydd i loggmeldingene etter testing
+//                log.info("Innlogget person representerer ingen organisasjoner")
+                secure(log).info("Innlogget person (fnr=$fnr) representerer ingen organisasjoner med rekrutteringsrettighet")
             } else {
-                log.info("Innlogget person representerer ${it.size} organisasjoner")
+//                log.info("Innlogget person representerer ${it.size} organisasjoner")
+                secure(log).info("Innlogget person (fnr=$fnr) representerer ${it.size} organisasjoner med rekrutteringsrettighet (${it.joinToString { it.organizationNumber }})")
                 cache.leggICache(fnr, it, ENKELTRETTIGHET_REKRUTTERING)
             }
         }
@@ -70,9 +73,11 @@ class AltinnKlient(
 
         return organisasjoner.also {
             if (it.isEmpty()) {
-                log.info("Innlogget person representerer ingen organisasjoner")
+//                log.info("Innlogget person representerer ingen organisasjoner")
+                secure(log).info("Innlogget person (fnr=$fnr) representerer ingen organisasjoner i Altinn")
             } else {
-                log.info("Innlogget person representerer ${it.size} organisasjoner")
+//                log.info("Innlogget person representerer ${it.size} organisasjoner")
+                secure(log).info("Innlogget person (fnr=$fnr) representerer ${it.size} organisasjoner i Altinn (${it.joinToString { it.organizationNumber }})")
                 cache.leggICache(fnr, it, INGEN)
             }
         }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnReportee.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnReportee.kt
@@ -1,10 +1,15 @@
 package no.nav.arbeidsgiver.toi.presentertekandidater.altinn
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.io.Serializable
 
 data class AltinnReportee(
+    @JsonProperty("Name")
     val name: String,
+    @JsonProperty("ParentOrganizationNumber")
     val parentOrganizationNumber: String?,
+    @JsonProperty("OrganizationNumber")
     val organizationNumber: String,
+    @JsonProperty("OrganizationForm")
     val organizationForm: String
 ) : Serializable

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnReportee.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnReportee.kt
@@ -1,0 +1,10 @@
+package no.nav.arbeidsgiver.toi.presentertekandidater.altinn
+
+import java.io.Serializable
+
+data class AltinnReportee(
+    val name: String,
+    val parentOrganizationNumber: String?,
+    val organizationNumber: String,
+    val organizationForm: String
+) : Serializable

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
@@ -1,5 +1,7 @@
 package no.nav.arbeidsgiver.toi.presentertekandidater.altinn
 
+import no.nav.arbeidsgiver.toi.presentertekandidater.SecureLogLogger.Companion.secure
+import no.nav.arbeidsgiver.toi.presentertekandidater.log
 import java.time.Duration
 import java.time.ZonedDateTime
 
@@ -24,6 +26,7 @@ class Cache(private val levetid: Duration) {
             cache.remove(nøkkel)
             null
         } else {
+            secure(log).info("Hentet organisasjoner med filtrering ${filtrering.name} fra cache for bruker med fnr $fødselsnummer")
             cachetOrganisasjoner.organisasjoner
         }
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
@@ -26,7 +26,6 @@ class Cache(private val levetid: Duration) {
             cache.remove(nøkkel)
             null
         } else {
-            secure(log).info("Hentet organisasjoner med filtrering ${filtrering.name} fra cache for bruker med fnr $fødselsnummer")
             cachetOrganisasjoner.organisasjoner
         }
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
@@ -43,7 +43,7 @@ class Cache(private val levetid: Duration) {
 
     enum class AltinnFiltrering {
         INGEN,
-        ENKELTRETTIGHET_REKRUTTERING
+        NAV_REKRUTTERING_KANDIDATER
     }
 
     fun tømCache() {

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
@@ -42,4 +42,8 @@ class Cache(private val levetid: Duration) {
         INGEN,
         ENKELTRETTIGHET_REKRUTTERING
     }
+
+    fun tømCache() {
+        cache.clear()
+    }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/Cache.kt
@@ -1,6 +1,5 @@
 package no.nav.arbeidsgiver.toi.presentertekandidater.altinn
 
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee
 import java.time.Duration
 import java.time.ZonedDateTime
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
@@ -32,11 +32,11 @@ fun startController(
 ) {
     javalin.routes {
         get("/organisasjoner", hentOrganisasjoner, Rolle.ARBEIDSGIVER)
-        get("/kandidatlister", hentKandidatlister(kandidatlisteRepository), Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING)
+        get("/kandidatlister", hentKandidatlister(kandidatlisteRepository), Rolle.ARBEIDSGIVER_MED_ROLLE_KANDIDATER)
         get(
             "/kandidatliste/{stillingId}",
             hentKandidatliste(kandidatlisteRepository, openSearchKlient),
-            Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING
+            Rolle.ARBEIDSGIVER_MED_ROLLE_KANDIDATER
         )
         get(
             "/kandidatliste/{stillingId}/vurdering",
@@ -49,13 +49,13 @@ fun startController(
         put(
             "/kandidat/{uuid}/vurdering",
             oppdaterArbeidsgiversVurdering(kandidatlisteRepository),
-            Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING
+            Rolle.ARBEIDSGIVER_MED_ROLLE_KANDIDATER
         )
-        delete("/kandidat/{uuid}", slettKandidat(kandidatlisteRepository), Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING)
+        delete("/kandidat/{uuid}", slettKandidat(kandidatlisteRepository), Rolle.ARBEIDSGIVER_MED_ROLLE_KANDIDATER)
         post(
             "/kandidat/{uuid}/registrerviskontaktinfo",
             registrerVisningAvKontaktInfo(kandidatlisteRepository, visningKontaktinfoRepository),
-            Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING
+            Rolle.ARBEIDSGIVER_MED_ROLLE_KANDIDATER
         )
         get(
             "/ekstern/antallkandidater",
@@ -253,18 +253,18 @@ fun Context.hentFødselsnummer(): String =
     attribute("fødselsnummer") ?: error("Context har ikke fødselsnummer")
 
 fun Context.setFødselsnummer(fødselsnummer: String) = attribute("fødselsnummer", fødselsnummer)
-fun Context.setOrganisasjonerForRekruttering(altinnReportee: List<AltinnReportee>) =
-    attribute("organisasjonerForRekruttering", altinnReportee)
+fun Context.setRepresenterteOrganisasjonerMedRettighetKandidater(altinnReportee: List<AltinnReportee>) =
+    attribute("representerteOrganisasjonerMedRettighetKandidater", altinnReportee)
 
-fun Context.hentOrganisasjonerForRekruttering(): List<AltinnReportee> =
-    attribute("organisasjonerForRekruttering") ?: error("Context har ikke organisasjoner for rekruttering.")
+fun Context.hentRepresenterteOrganisasjonerMedRettighetKandidater(): List<AltinnReportee> =
+    attribute("representerteOrganisasjonerMedRettighetKandidater") ?: error("Context har ikke organisasjoner for kandidater.")
 
 fun Context.validerRekruttererRolleIOrganisasjon(virksomhetsnummer: String) {
     val representererVirksomhet =
-        virksomhetsnummer in this.hentOrganisasjonerForRekruttering().map { it.organizationNumber }
+        virksomhetsnummer in this.hentRepresenterteOrganisasjonerMedRettighetKandidater().map { it.organizationNumber }
     if (!representererVirksomhet) {
-        this@validerRekruttererRolleIOrganisasjon.log.info("Bruker har ikke enkeltrettighet Rekruttering for angitt virksomhet. Se virksomhetsnummer i SecureLog")
-        secure(this@validerRekruttererRolleIOrganisasjon.log).info("Bruker har ikke enkeltrettighet Rekruttering for virksomheten ${virksomhetsnummer}")
-        throw ForbiddenResponse("Bruker har ikke enkeltrettighet Rekruttering for angitt virksomhet")
+        this@validerRekruttererRolleIOrganisasjon.log.info("Bruker har ikke enkeltrettighet nav_rekruttering_kandidater for angitt virksomhet. Se virksomhetsnummer i SecureLog")
+        secure(this@validerRekruttererRolleIOrganisasjon.log).info("Bruker har ikke enkeltrettighet nav_rekruttering_kandidater for virksomheten ${virksomhetsnummer}")
+        throw ForbiddenResponse("Bruker har ikke enkeltrettighet nav_rekruttering_kandidater for angitt virksomhet")
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
@@ -258,17 +258,15 @@ fun Context.setFødselsnummer(fødselsnummer: String) = attribute("fødselsnumme
 fun Context.setOrganisasjonerForRekruttering(altinnReportee: List<AltinnReportee>) =
     attribute("organisasjonerForRekruttering", altinnReportee)
 
-fun Context.setOrganisasjonerForRekruttering(): List<AltinnReportee> =
+fun Context.hentOrganisasjonerForRekruttering(): List<AltinnReportee> =
     attribute("organisasjonerForRekruttering") ?: error("Context har ikke organisasjoner for rekruttering.")
 
 fun Context.validerRekruttererRolleIOrganisasjon(virksomhetsnummer: String) {
     val representererVirksomhet =
-        virksomhetsnummer in this.setOrganisasjonerForRekruttering().map { it.organizationNumber }
+        virksomhetsnummer in this.hentOrganisasjonerForRekruttering().map { it.organizationNumber }
     if (!representererVirksomhet) {
         this@validerRekruttererRolleIOrganisasjon.log.info("Bruker har ikke enkeltrettighet Rekruttering for angitt virksomhet. Se virksomhetsnummer i SecureLog")
         secure(this@validerRekruttererRolleIOrganisasjon.log).info("Bruker har ikke enkeltrettighet Rekruttering for virksomheten ${virksomhetsnummer}")
         throw ForbiddenResponse("Bruker har ikke enkeltrettighet Rekruttering for angitt virksomhet")
     }
 }
-
-

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controller.kt
@@ -6,8 +6,8 @@ import io.javalin.http.BadRequestResponse
 import io.javalin.http.Context
 import io.javalin.http.ForbiddenResponse
 import io.javalin.http.InternalServerErrorResponse
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee
 import no.nav.arbeidsgiver.toi.presentertekandidater.SecureLogLogger.Companion.secure
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnReportee
 import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.Kandidat
 import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.Kandidatliste
 import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.KandidatlisteMedAntallKandidater

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/sikkerhet/securityConfig.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/sikkerhet/securityConfig.kt
@@ -15,7 +15,7 @@ import no.nav.arbeidsgiver.toi.presentertekandidater.navalin.RolleKonfigurasjon
 import no.nav.arbeidsgiver.toi.presentertekandidater.samtykke.SamtykkeRepository
 import no.nav.arbeidsgiver.toi.presentertekandidater.setFødselsnummer
 import no.nav.arbeidsgiver.toi.presentertekandidater.setOrganisasjoner
-import no.nav.arbeidsgiver.toi.presentertekandidater.setOrganisasjonerForRekruttering
+import no.nav.arbeidsgiver.toi.presentertekandidater.setRepresenterteOrganisasjonerMedRettighetKandidater
 import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import org.eclipse.jetty.http.HttpStatus
 
@@ -27,14 +27,14 @@ fun konfigurerRoller(altinnKlient: AltinnKlient, samtykkeRepository: SamtykkeRep
         validerAutorisering = hentRepresenterteOrganisasjoner(altinnKlient)
     ),
     RolleKonfigurasjon(
-        rolle = Rolle.ARBEIDSGIVER_MED_ROLLE_REKRUTTERING,
+        rolle = Rolle.ARBEIDSGIVER_MED_ROLLE_KANDIDATER,
         tokenUtsteder = TOKEN_X,
-        validerAutorisering = validerSamtykkeOgRolleRekruttering(altinnKlient, samtykkeRepository)
+        validerAutorisering = validerSamtykkeOgRolleKandidater(altinnKlient, samtykkeRepository)
     ),
     RolleKonfigurasjon(
         rolle = Rolle.EKSTERN_ARBEIDSGIVER,
         tokenUtsteder = TOKEN_X,
-        validerAutorisering = validerRepresentererOrganisasjonMedRolleRekruttering(altinnKlient)
+        validerAutorisering = validerRepresentererOrganisasjonMedRolleKandidater(altinnKlient)
     ),
     RolleKonfigurasjon(
         rolle = Rolle.VEILEDER,
@@ -48,13 +48,13 @@ fun konfigurerRoller(altinnKlient: AltinnKlient, samtykkeRepository: SamtykkeRep
 )
 
 enum class Rolle : RouteRole {
-    ARBEIDSGIVER, UNPROTECTED, ARBEIDSGIVER_MED_ROLLE_REKRUTTERING, EKSTERN_ARBEIDSGIVER, VEILEDER
+    ARBEIDSGIVER, UNPROTECTED, ARBEIDSGIVER_MED_ROLLE_KANDIDATER, EKSTERN_ARBEIDSGIVER, VEILEDER
 }
 
-val validerSamtykkeOgRolleRekruttering: (AltinnKlient, SamtykkeRepository) -> (JwtTokenClaims, Context, AccessToken) -> Unit =
+val validerSamtykkeOgRolleKandidater: (AltinnKlient, SamtykkeRepository) -> (JwtTokenClaims, Context, AccessToken) -> Unit =
     { altinnKlient, samtykkeRepository ->
         { jwtTokenClaims, context, accessToken ->
-            validerRepresentererOrganisasjonMedRolleRekruttering(altinnKlient)(
+            validerRepresentererOrganisasjonMedRolleKandidater(altinnKlient)(
                 jwtTokenClaims,
                 context,
                 accessToken
@@ -76,19 +76,19 @@ val validerSamtykke: (SamtykkeRepository) -> (JwtTokenClaims, Context, AccessTok
         }
     }
 
-val validerRepresentererOrganisasjonMedRolleRekruttering: (AltinnKlient) -> (JwtTokenClaims, Context, AccessToken) -> Unit =
+val validerRepresentererOrganisasjonMedRolleKandidater: (AltinnKlient) -> (JwtTokenClaims, Context, AccessToken) -> Unit =
     { altinnKlient ->
         { jwtTokenClaims, context, accessToken ->
             settFødselsnummerPåKontekst(jwtTokenClaims, context)
             val fnr = context.hentFødselsnummer()
 
             val organisasjoner =
-                altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn(fnr, accessToken)
+                altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn(fnr, accessToken)
 
             if (organisasjoner.isEmpty()) {
                 throw UnauthorizedResponse()
             } else {
-                context.setOrganisasjonerForRekruttering(organisasjoner)
+                context.setRepresenterteOrganisasjonerMedRettighetKandidater(organisasjoner)
             }
         }
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/utils.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/utils.kt
@@ -30,7 +30,7 @@ fun noClassLogger(): Logger {
 }
 
 /**
- * Styrer logging til [secureLog](https://doc.nais.io/observability/logs/#secure-logs), forutsatt riktig konfigurasjon av Logback.
+ * Styrer logging til [team-logs](https://doc.nais.io/observability/logging/#team-logs), forutsatt riktig konfigurasjon av Logback.
  *
  * Brukes ved å dekorere en hvilken som helst, vanlig org.slf4j.Logger slik:
  * ```
@@ -39,25 +39,25 @@ fun noClassLogger(): Logger {
  * secure(log).info(msg)
  * ```
  *
- * For at dette skal virke må appens fil `logback.xml` bruke appendere med filtere slik at logging events som har en marker med navn `SECURE_LOG` styres til riktig loggfil:
+ * For at dette skal virke må appens fil `logback.xml` bruke appendere med filtere slik at logging events som har en marker med navn `TEAM_LOGS` styres til riktig loggfil:
  * ```
  * <configuration>
  *     <appender name="appLog" ...>
  *         ...
  *         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
  *             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
- *                 <marker>SECURE_LOG</marker>
+ *                 <marker>TEAM_LOGS</marker>
  *             </evaluator>
  *             <OnMismatch>NEUTRAL</OnMismatch>
  *             <OnMatch>DENY</OnMatch>
  *         </filter>
  *     </appender>
  *
- *     <appender name="secureLog" ...>
+ *     <appender name="team-logs" ...>
  *         ...
  *         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
  *             <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
- *                 <marker>SECURE_LOG</marker>
+ *                 <marker>TEAM_LOGS</marker>
  *             </evaluator>
  *             <OnMismatch>DENY</OnMismatch>
  *             <OnMatch>NEUTRAL</OnMatch>
@@ -66,8 +66,12 @@ fun noClassLogger(): Logger {
  *
  *     <root ...>
  *         <appender-ref ref="appLog"/>
- *         <appender-ref ref="secureLog"/>
+ *         <appender-ref ref="team-logs"/>
  *     </root>
+ *
+ *     <logger name="team-logs-logger" level="INFO" additivity="false">
+ *          <appender-ref ref="team-logs" />
+ *     </logger>
  * </configuration>
  * ```
  * Se [offisiell Logback-dokumentasjon](https://logback.qos.ch/manual/filters.html#evaluatorFilter)
@@ -75,7 +79,7 @@ fun noClassLogger(): Logger {
  */
 class SecureLogLogger private constructor(private val l: Logger) {
 
-    val markerName: String = "SECURE_LOG"
+    val markerName: String = "TEAM_LOGS"
 
     private val m: Marker = MarkerFactory.getMarker(markerName)
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.toi.presentertekandidater
 
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnReportee
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnTilgang
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnTilgangerResponse
 import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.Kandidat
 import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.Kandidatliste
 import java.math.BigInteger
@@ -1290,12 +1292,20 @@ object Testdata {
     fun lagAltinnOrganisasjon(navn: String = "bedriftsnavn", orgNummer: String = "123456789"): AltinnReportee =
         AltinnReportee(
             name = navn,
-            type = "dummy",
             parentOrganizationNumber = "dummy",
             organizationNumber = orgNummer,
-            organizationForm = "dummy",
-            status = "dummy",
-            socialSecurityNumber = ""
+            organizationForm = "dummy"
+        )
+
+    fun lagAltinnTilgang(navn: String = "bedriftsnavn", orgNummer: String = "123456789"): AltinnTilgang =
+        AltinnTilgang(
+            orgnr = orgNummer,
+            altinn3Tilganger = setOf("ressursid"),
+            altinn2Tilganger = setOf("servicecode:serviceedition"),
+            underenheter = emptyList(),
+            navn = navn,
+            organisasjonsform = "dummy",
+            erSlettet = false,
         )
 
     fun kandidatliste(uuid: UUID = UUID.randomUUID()) = Kandidatliste(

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
@@ -1314,8 +1314,8 @@ object Testdata {
     ): AltinnTilgang {
         val underenhet = AltinnTilgang(
             orgnr = underenhetOrgNummer,
-            altinn2Tilganger = setOf("5078:1"),
-            altinn3Tilganger = emptySet(),
+            altinn2Tilganger = emptySet(),
+            altinn3Tilganger = setOf("nav_rekruttering_kandidater"),
             underenheter = emptyList(),
             navn = "$navn - underenhet",
             organisasjonsform = "dummy",

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
@@ -1296,7 +1296,7 @@ object Testdata {
             organizationForm = "dummy"
         )
 
-    fun lagAltinnTilgangUtenRekrutteringsrettighet(navn: String = "bedriftsnavn", orgNummer: String = "123456789"): AltinnTilgang =
+    fun lagAltinnTilgangUtenRettighetKandidater(navn: String = "bedriftsnavn", orgNummer: String = "123456789"): AltinnTilgang =
         AltinnTilgang(
             orgnr = orgNummer,
             altinn2Tilganger = setOf("servicecode:serviceedition"),
@@ -1307,7 +1307,7 @@ object Testdata {
             erSlettet = false,
         )
 
-    fun lagAltinnTilgangMedRekrutteringsrettighet(
+    fun lagAltinnTilgangMedRettighetKandidater(
         navn: String = "bedriftsnavn",
         underenhetOrgNummer: String = "123456789",
         orgNummer: String = "999888777"

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
@@ -1297,16 +1297,37 @@ object Testdata {
             organizationForm = "dummy"
         )
 
-    fun lagAltinnTilgang(navn: String = "bedriftsnavn", orgNummer: String = "123456789"): AltinnTilgang =
+    fun lagAltinnTilgangUtenRekrutteringsrettighet(navn: String = "bedriftsnavn", orgNummer: String = "123456789"): AltinnTilgang =
         AltinnTilgang(
             orgnr = orgNummer,
-            altinn3Tilganger = setOf("ressursid"),
             altinn2Tilganger = setOf("servicecode:serviceedition"),
+            altinn3Tilganger = setOf("ressursid"),
             underenheter = emptyList(),
             navn = navn,
             organisasjonsform = "dummy",
             erSlettet = false,
         )
+
+    fun lagAltinnTilgangMedRekrutteringsrettighet(navn: String = "bedriftsnavn", orgNummer: String = "123456789"): AltinnTilgang {
+        val underenhet = AltinnTilgang(
+            orgnr = orgNummer,
+            altinn2Tilganger = setOf("5078:1"),
+            altinn3Tilganger = emptySet(),
+            underenheter = emptyList(),
+            navn = navn,
+            organisasjonsform = "dummy",
+            erSlettet = false,
+        )
+        return AltinnTilgang(
+            orgnr = orgNummer,
+            altinn2Tilganger = emptySet(),
+            altinn3Tilganger = emptySet(),
+            underenheter = listOf(underenhet),
+            navn = navn,
+            organisasjonsform = "dummy",
+            erSlettet = false,
+        )
+    }
 
     fun kandidatliste(uuid: UUID = UUID.randomUUID()) = Kandidatliste(
         stillingId = uuid,

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/Testdata.kt
@@ -2,7 +2,6 @@ package no.nav.arbeidsgiver.toi.presentertekandidater
 
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnReportee
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnTilgang
-import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnTilgangerResponse
 import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.Kandidat
 import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.Kandidatliste
 import java.math.BigInteger
@@ -1308,13 +1307,17 @@ object Testdata {
             erSlettet = false,
         )
 
-    fun lagAltinnTilgangMedRekrutteringsrettighet(navn: String = "bedriftsnavn", orgNummer: String = "123456789"): AltinnTilgang {
+    fun lagAltinnTilgangMedRekrutteringsrettighet(
+        navn: String = "bedriftsnavn",
+        underenhetOrgNummer: String = "123456789",
+        orgNummer: String = "999888777"
+    ): AltinnTilgang {
         val underenhet = AltinnTilgang(
-            orgnr = orgNummer,
+            orgnr = underenhetOrgNummer,
             altinn2Tilganger = setOf("5078:1"),
             altinn3Tilganger = emptySet(),
             underenheter = emptyList(),
-            navn = navn,
+            navn = "$navn - underenhet",
             organisasjonsform = "dummy",
             erSlettet = false,
         )

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
@@ -1,0 +1,261 @@
+package no.nav.arbeidsgiver.toi.presentertekandidater.altinn
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.http.Fault
+import no.nav.arbeidsgiver.toi.presentertekandidater.sikkerhet.TokendingsKlient
+import org.junit.jupiter.api.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class AltinnKlientTest {
+    companion object {
+        private lateinit var wireMockServer: WireMockServer
+        private lateinit var altinnKlient: AltinnKlient
+        private lateinit var tokendingsKlient: TokendingsKlient
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            wireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
+            wireMockServer.start()
+
+            tokendingsKlient = mock(TokendingsKlient::class.java)
+            `when`(
+                tokendingsKlient.veksleInnToken(
+                    "test-token",
+                    "altinn-scope"
+                )
+            ).thenReturn("mocked-token")
+
+            val testEnv = mapOf(
+                "ALTINN_PROXY_URL" to "http://localhost:${wireMockServer.port()}/altinn-tilganger",
+                "ALTINN_PROXY_AUDIENCE" to "din:app",
+                "ALTINN_SCOPE" to "altinn-scope"
+            )
+            altinnKlient = AltinnKlient(testEnv, tokendingsKlient)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun teardown() {
+            wireMockServer.stop()
+        }
+    }
+
+    @BeforeEach
+    fun reset() {
+        wireMockServer.resetAll()
+    }
+
+    @Test
+    fun `Skal returnere organisasjoner ved OK respons fra Altinn`() {
+        val accessToken = "test-token"
+        val altinnResponseJson = """
+            {
+                "isError": false,
+                "hierarki": [
+                    {
+                        "orgnr": "999888777",
+                        "navn": "TESTORGANISASJON AS",
+                        "altinn2Tilganger": ["5078:1"],
+                        "altinn3Tilganger": [],
+                        "underenheter": [],
+                        "organisasjonsform": "AS",
+                        "erSlettet": false
+                    }
+                ],
+                "orgNrTilTilganger": {
+                    "999888777": ["5078:1"]
+                },
+                "tilgangTilOrgNr": {
+                    "5078:1": ["999888777"]
+                }
+            }
+        """.trimIndent()
+
+        wireMockServer.stubFor(
+            WireMock.post("/altinn-tilganger")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(altinnResponseJson)
+                )
+        )
+
+        val organisasjoner = altinnKlient.hentOrganisasjoner("12345678901", accessToken)
+        Assertions.assertEquals(1, organisasjoner.size)
+        Assertions.assertEquals("TESTORGANISASJON AS", organisasjoner[0].name)
+        Assertions.assertEquals("999888777", organisasjoner[0].organizationNumber)
+        wireMockServer.verify(
+            1, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
+        )
+
+        val organisasjonerMedRekrutteringsrettighet =
+            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+        Assertions.assertEquals(1, organisasjonerMedRekrutteringsrettighet.size)
+        Assertions.assertEquals("TESTORGANISASJON AS", organisasjonerMedRekrutteringsrettighet[0].name)
+        Assertions.assertEquals("999888777", organisasjonerMedRekrutteringsrettighet[0].organizationNumber)
+        wireMockServer.verify(
+            2, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
+        )
+    }
+
+    @Test
+    fun `Skal kaste AltinnServiceException ved http 401 fra Altinn`() {
+        val accessToken = "test-token"
+
+        wireMockServer.stubFor(
+            WireMock.post("/altinn-tilganger")
+                .willReturn(
+                    aResponse()
+                        .withStatus(401)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("Unauthorized")
+                )
+        )
+
+        assertThrows<AltinnServiceException> {
+            altinnKlient.hentOrganisasjoner("12345678901", accessToken)
+        }
+
+        assertThrows<AltinnServiceException> {
+            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+        }
+    }
+
+    @Test
+    fun `Skal prøve på nytt ved midlertidig feil fra Altinn`() {
+        val accessToken = "test-token"
+
+        wireMockServer.stubFor(
+            WireMock.post("/altinn-tilganger")
+                .willReturn(
+                    aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("Internal Server Error")
+                )
+        )
+
+        // Sjekk at AltinnKlient prøver på nytt 3 ganger før den kaster exception ved `hentOrganisasjoner`
+        assertThrows<AltinnServiceException> {
+            altinnKlient.hentOrganisasjoner("12345678901", accessToken)
+        }
+
+        wireMockServer.verify(
+            3,
+            WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
+        )
+
+        // Sjekk at AltinnKlient prøver på nytt nye 3 ganger før den kaster exception ved `hentOrganisasjonerMedRettighetRekrutteringFraAltinn`
+        assertThrows<AltinnServiceException> {
+            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+        }
+
+        wireMockServer.verify(
+            6,
+            WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
+        )
+    }
+
+    @Test
+    fun `Skal ikke returnere organisasjoner når Altinn ikke returnerer noen tilganger`() {
+        val accessToken = "test-token"
+        val altinnResponseJson = """
+            {
+                "isError": false,
+                "hierarki": [],
+                "orgNrTilTilganger": {},
+                "tilgangTilOrgNr": {}
+            }
+        """.trimIndent()
+
+        wireMockServer.stubFor(
+            WireMock.post("/altinn-tilganger")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(altinnResponseJson)
+                )
+        )
+
+        val organisasjoner = altinnKlient.hentOrganisasjoner("12345678901", accessToken)
+        Assertions.assertTrue(organisasjoner.isEmpty())
+
+        val organisasjonerMedRekrutteringsrettighet =
+            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+        Assertions.assertTrue(organisasjonerMedRekrutteringsrettighet.isEmpty())
+    }
+
+    @Test
+    fun `Skal kaste AltinnException ved isError true og tomme tilgangsdata fra Altinn`() {
+        val accessToken = "test-token"
+        val altinnResponseJson = """
+            {
+                "isError": true,
+                "hierarki": [],
+                "orgNrTilTilganger": {},
+                "tilgangTilOrgNr": {}
+            }
+        """.trimIndent()
+
+        wireMockServer.stubFor(
+            WireMock.post("/altinn-tilganger")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(altinnResponseJson)
+                )
+        )
+
+        // Verifiser at det ble prøvd på nytt 3 ganger og deretter kastet exception
+        assertThrows<AltinnException> {
+            altinnKlient.hentOrganisasjoner("12345678901", accessToken)
+        }
+        wireMockServer.verify(
+            3, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
+        )
+
+        // Verifiser at det ble prøvd på nytt 3 ganger og deretter kastet exception
+        assertThrows<AltinnException> {
+            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+        }
+        wireMockServer.verify(
+            6, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
+        )
+    }
+
+    @Test
+    fun `Skal kaste AltinnServiceException ved nettverksfeil mot Altinn`() {
+        val accessToken = "test-token"
+        wireMockServer.stubFor(
+            WireMock.post("/altinn-tilganger")
+                .willReturn(
+                    aResponse()
+                        .withFault(Fault.CONNECTION_RESET_BY_PEER)
+                )
+        )
+
+        // Verifiser at det ble prøvd på nytt 3 ganger og deretter kastet exception
+        assertThrows<AltinnException> {
+            altinnKlient.hentOrganisasjoner("12345678901", accessToken)
+        }
+        wireMockServer.verify(
+            3, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
+        )
+
+        // Verifiser at det ble prøvd på nytt 3 ganger og deretter kastet exception
+        assertThrows<AltinnException> {
+            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+        }
+        wireMockServer.verify(
+            6, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
@@ -391,7 +391,7 @@ class AltinnKlientTest {
         Assertions.assertEquals(underenhetOrgnr, organisasjoner[1].organizationNumber)
         Assertions.assertEquals(overenhetOrgnr, organisasjoner[1].parentOrganizationNumber)
 
-        //Rrettighet nav_rekruttering_kandidater mangler på overenhet, dermed skal kun underenheten med
+        // Rettighet nav_rekruttering_kandidater mangler på overenhet, dermed skal kun underenheten med
         val organisasjonerMedRettighetKandidater =
             altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", accessToken)
         Assertions.assertEquals(1, organisasjonerMedRettighetKandidater.size)
@@ -490,7 +490,7 @@ class AltinnKlientTest {
                     "altinn2Tilganger": [],
                     "altinn3Tilganger": [],
                     "underenheter": [
-                                            {
+                        {
                             "orgnr": "222222221",
                             "navn": "UNDERENHET UTEN RETTIGHET",
                             "altinn2Tilganger": [],
@@ -511,7 +511,7 @@ class AltinnKlientTest {
                 "222222221": []
             },
             "tilgangTilOrgNr": {
-                "nav_rekruttering_kandidater": ["111111111", 111111112]
+                "nav_rekruttering_kandidater": ["111111111", "111111112"]
             }
         }
     """.trimIndent()

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
@@ -106,11 +106,11 @@ class AltinnKlientTest {
             1, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
         )
 
-        val organisasjonerMedRekrutteringsrettighet =
-            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
-        Assertions.assertEquals(1, organisasjonerMedRekrutteringsrettighet.size)
-        Assertions.assertEquals("UNDERENHET AV TESTORGANISASJON AS", organisasjonerMedRekrutteringsrettighet[0].name)
-        Assertions.assertEquals("999888778", organisasjonerMedRekrutteringsrettighet[0].organizationNumber)
+        val organisasjonerMedRettighetKandidater =
+            altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", accessToken)
+        Assertions.assertEquals(1, organisasjonerMedRettighetKandidater.size)
+        Assertions.assertEquals("UNDERENHET AV TESTORGANISASJON AS", organisasjonerMedRettighetKandidater[0].name)
+        Assertions.assertEquals("999888778", organisasjonerMedRettighetKandidater[0].organizationNumber)
         wireMockServer.verify(
             2, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
         )
@@ -135,7 +135,7 @@ class AltinnKlientTest {
         }
 
         assertThrows<AltinnServiceException> {
-            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+            altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", accessToken)
         }
     }
 
@@ -163,9 +163,9 @@ class AltinnKlientTest {
             WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
         )
 
-        // Sjekk at AltinnKlient prøver på nytt nye 3 ganger før den kaster exception ved `hentOrganisasjonerMedRettighetRekrutteringFraAltinn`
+        // Sjekk at AltinnKlient prøver på nytt nye 3 ganger før den kaster exception ved `hentOrganisasjonerMedRettighetKandidaterFraAltinn`
         assertThrows<AltinnServiceException> {
-            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+            altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", accessToken)
         }
 
         wireMockServer.verify(
@@ -199,9 +199,9 @@ class AltinnKlientTest {
         val organisasjoner = altinnKlient.hentOrganisasjoner("12345678901", accessToken)
         Assertions.assertTrue(organisasjoner.isEmpty())
 
-        val organisasjonerMedRekrutteringsrettighet =
-            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
-        Assertions.assertTrue(organisasjonerMedRekrutteringsrettighet.isEmpty())
+        val organisasjonerMedRettighetKandidater =
+            altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", accessToken)
+        Assertions.assertTrue(organisasjonerMedRettighetKandidater.isEmpty())
     }
 
     @Test
@@ -236,7 +236,7 @@ class AltinnKlientTest {
 
         // Verifiser at det ble prøvd på nytt 3 ganger og deretter kastet exception
         assertThrows<AltinnException> {
-            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+            altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", accessToken)
         }
         wireMockServer.verify(
             6, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
@@ -264,7 +264,7 @@ class AltinnKlientTest {
 
         // Verifiser at det ble prøvd på nytt 3 ganger og deretter kastet exception
         assertThrows<AltinnException> {
-            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
+            altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", accessToken)
         }
         wireMockServer.verify(
             6, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger"))
@@ -326,16 +326,16 @@ class AltinnKlientTest {
         Assertions.assertEquals(underenhetOrgnr, organisasjoner[1].organizationNumber)
         Assertions.assertEquals(overenhetOrgnr, organisasjoner[1].parentOrganizationNumber)
 
-        // Rekrutteringsrettighet mangler på overenhet, dermed skal kun underenheten med
-        val organisasjonerMedRekrutteringsrettighet =
-            altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", accessToken)
-        Assertions.assertEquals(1, organisasjonerMedRekrutteringsrettighet.size)
-        Assertions.assertEquals(underenhetOrgnr, organisasjonerMedRekrutteringsrettighet[0].organizationNumber)
-        Assertions.assertEquals(overenhetOrgnr, organisasjonerMedRekrutteringsrettighet[0].parentOrganizationNumber)
+        //Rrettighet nav_rekruttering_kandidater mangler på overenhet, dermed skal kun underenheten med
+        val organisasjonerMedRettighetKandidater =
+            altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", accessToken)
+        Assertions.assertEquals(1, organisasjonerMedRettighetKandidater.size)
+        Assertions.assertEquals(underenhetOrgnr, organisasjonerMedRettighetKandidater[0].organizationNumber)
+        Assertions.assertEquals(overenhetOrgnr, organisasjonerMedRettighetKandidater[0].parentOrganizationNumber)
     }
 
     @Test
-    fun `hentOrganisasjonerMedRettighetRekrutteringFraAltinn skal kun returnere underenheter`() {
+    fun `hentOrganisasjonerMedRettighetKandidaterFraAltinn skal kun returnere underenheter`() {
         val altinnResponseJson = """
         {
             "isError": false,
@@ -389,13 +389,13 @@ class AltinnKlientTest {
                 )
         )
 
-        val result = altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", "token")
+        val result = altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", "token")
         Assertions.assertEquals(1, result.size)
         Assertions.assertEquals("111111112", result[0].organizationNumber)
     }
 
     @Test
-    fun `hentOrganisasjonerMedRettighetRekrutteringFraAltinn skal kun returnere organisasjoner med rekrutteringsrettighet`() {
+    fun `hentOrganisasjonerMedRettighetKandidaterFraAltinn skal kun returnere organisasjoner med riktig rettighet`() {
         val altinnResponseJson = """
         {
             "isError": false,
@@ -460,7 +460,7 @@ class AltinnKlientTest {
                 )
         )
 
-        val result = altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", "token")
+        val result = altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", "token")
         Assertions.assertEquals(1, result.size)
         Assertions.assertEquals("111111112", result[0].organizationNumber)
     }
@@ -500,7 +500,7 @@ class AltinnKlientTest {
         )
 
         altinnKlient.hentOrganisasjoner("12345678901", "token")
-        altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", "token")
+        altinnKlient.hentOrganisasjonerMedRettighetKandidaterFraAltinn("12345678901", "token")
 
         wireMockServer.verify(2, WireMock.postRequestedFor(WireMock.urlEqualTo("/altinn-tilganger")))
     }

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
@@ -61,14 +61,14 @@ class AltinnKlientTest {
                     {
                         "orgnr": "999888777",
                         "navn": "TESTORGANISASJON AS",
-                        "altinn2Tilganger": ["5078:1"],
-                        "altinn3Tilganger": [],
+                        "altinn2Tilganger": [],
+                        "altinn3Tilganger": ["nav_rekruttering_kandidater"],
                         "underenheter": [
                             {
                                 "orgnr": "999888778",
                                 "navn": "UNDERENHET AV TESTORGANISASJON AS",
-                                "altinn2Tilganger": ["5078:1"],
-                                "altinn3Tilganger": [],
+                                "altinn2Tilganger": [],
+                                "altinn3Tilganger": ["nav_rekruttering_kandidater"],
                                 "underenheter": [],
                                 "organisasjonsform": "AS",
                                 "erSlettet": false
@@ -79,11 +79,11 @@ class AltinnKlientTest {
                     }
                 ],
                 "orgNrTilTilganger": {
-                    "999888777": ["5078:1"],
-                    "999888778": ["5078:1"]
+                    "999888777": ["nav_rekruttering_kandidater"],
+                    "999888778": ["nav_rekruttering_kandidater"]
                 },
                 "tilgangTilOrgNr": {
-                    "5078:1": ["999888777", "999888778"]
+                    "nav_rekruttering_kandidater": ["999888777", "999888778"]
                 }
             }
         """.trimIndent()
@@ -289,8 +289,8 @@ class AltinnKlientTest {
                             {
                                 "orgnr": "$underenhetOrgnr",
                                 "navn": "UNDERENHET AV TESTORGANISASJON AS",
-                                "altinn2Tilganger": ["5078:1"],
-                                "altinn3Tilganger": [],
+                                "altinn2Tilganger": [],
+                                "altinn3Tilganger": ["nav_rekruttering_kandidater"],
                                 "underenheter": [],
                                 "organisasjonsform": "AS",
                                 "erSlettet": false
@@ -301,10 +301,10 @@ class AltinnKlientTest {
                     }
                 ],
                 "orgNrTilTilganger": {
-                    "$underenhetOrgnr": ["5078:1"]
+                    "$underenhetOrgnr": ["nav_rekruttering_kandidater"]
                 },
                 "tilgangTilOrgNr": {
-                    "5078:1": ["$underenhetOrgnr"]
+                    "nav_rekruttering_kandidater": ["$underenhetOrgnr"]
                 }
             }
         """.trimIndent()
@@ -343,14 +343,14 @@ class AltinnKlientTest {
                 {
                     "orgnr": "111111111",
                     "navn": "OVERENHET MED RETTIGHET",
-                    "altinn2Tilganger": ["5078:1"],
-                    "altinn3Tilganger": [],
+                    "altinn2Tilganger": [],
+                    "altinn3Tilganger": ["nav_rekruttering_kandidater"],
                     "underenheter": [
                         {
                             "orgnr": "111111112",
                             "navn": "UNDERENHET MED RETTIGHET",
-                            "altinn2Tilganger": ["5078:1"],
-                            "altinn3Tilganger": [],
+                            "altinn2Tilganger": [],
+                            "altinn3Tilganger": ["nav_rekruttering_kandidater"],
                             "underenheter": [],
                             "organisasjonsform": "AS",
                             "erSlettet": false
@@ -370,12 +370,12 @@ class AltinnKlientTest {
                 }
             ],
             "orgNrTilTilganger": {
-                "111111111": ["5078:1"],
-                "111111112": ["5078:1"],
+                "111111111": ["nav_rekruttering_kandidater"],
+                "111111112": ["nav_rekruttering_kandidater"],
                 "222222222": []
             },
             "tilgangTilOrgNr": {
-                "5078:1": ["111111111", "111111112"]
+                "nav_rekruttering_kandidater": ["111111111", "111111112"]
             }
         }
     """.trimIndent()
@@ -403,14 +403,14 @@ class AltinnKlientTest {
                 {
                     "orgnr": "111111111",
                     "navn": "OVERENHET MED RETTIGHET",
-                    "altinn2Tilganger": ["5078:1"],
-                    "altinn3Tilganger": [],
+                    "altinn2Tilganger": [],
+                    "altinn3Tilganger": ["nav_rekruttering_kandidater"],
                     "underenheter": [
                         {
                             "orgnr": "111111112",
                             "navn": "UNDERENHET MED RETTIGHET",
-                            "altinn2Tilganger": ["5078:1"],
-                            "altinn3Tilganger": [],
+                            "altinn2Tilganger": [],
+                            "altinn3Tilganger": ["nav_rekruttering_kandidater"],
                             "underenheter": [],
                             "organisasjonsform": "AS",
                             "erSlettet": false
@@ -440,13 +440,13 @@ class AltinnKlientTest {
                 }
             ],
             "orgNrTilTilganger": {
-                "111111111": ["5078:1"],
-                "111111112": ["5078:1"],
+                "111111111": ["nav_rekruttering_kandidater"],
+                "111111112": ["nav_rekruttering_kandidater"],
                 "222222222": [],
                 "222222221": []
             },
             "tilgangTilOrgNr": {
-                "5078:1": ["111111111", 111111112]
+                "nav_rekruttering_kandidater": ["111111111", 111111112]
             }
         }
     """.trimIndent()
@@ -474,18 +474,18 @@ class AltinnKlientTest {
                 {
                     "orgnr": "999888777",
                     "navn": "TEST AS",
-                    "altinn2Tilganger": ["5078:1"],
-                    "altinn3Tilganger": [],
+                    "altinn2Tilganger": [],
+                    "altinn3Tilganger": ["nav_rekruttering_kandidater"],
                     "underenheter": [],
                     "organisasjonsform": "AS",
                     "erSlettet": false
                 }
             ],
             "orgNrTilTilganger": {
-                "999888777": ["5078:1"]
+                "999888777": ["nav_rekruttering_kandidater"]
             },
             "tilgangTilOrgNr": {
-                "5078:1": ["999888777"]
+                "nav_rekruttering_kandidater": ["999888777"]
             }
         }
     """.trimIndent()

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
@@ -371,10 +371,82 @@ class AltinnKlientTest {
             ],
             "orgNrTilTilganger": {
                 "111111111": ["5078:1"],
+                "111111112": ["5078:1"],
                 "222222222": []
             },
             "tilgangTilOrgNr": {
-                "5078:1": ["111111111"]
+                "5078:1": ["111111111", "111111112"]
+            }
+        }
+    """.trimIndent()
+
+        wireMockServer.stubFor(
+            WireMock.post("/altinn-tilganger")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withBody(altinnResponseJson)
+                )
+        )
+
+        val result = altinnKlient.hentOrganisasjonerMedRettighetRekrutteringFraAltinn("12345678901", "token")
+        Assertions.assertEquals(1, result.size)
+        Assertions.assertEquals("111111112", result[0].organizationNumber)
+    }
+
+    @Test
+    fun `hentOrganisasjonerMedRettighetRekrutteringFraAltinn skal kun returnere organisasjoner med rekrutteringsrettighet`() {
+        val altinnResponseJson = """
+        {
+            "isError": false,
+            "hierarki": [
+                {
+                    "orgnr": "111111111",
+                    "navn": "OVERENHET MED RETTIGHET",
+                    "altinn2Tilganger": ["5078:1"],
+                    "altinn3Tilganger": [],
+                    "underenheter": [
+                        {
+                            "orgnr": "111111112",
+                            "navn": "UNDERENHET MED RETTIGHET",
+                            "altinn2Tilganger": ["5078:1"],
+                            "altinn3Tilganger": [],
+                            "underenheter": [],
+                            "organisasjonsform": "AS",
+                            "erSlettet": false
+                        }
+                    ],
+                    "organisasjonsform": "AS",
+                    "erSlettet": false
+                },
+                {
+                    "orgnr": "222222222",
+                    "navn": "OVERENHET UTEN RETTIGHET",
+                    "altinn2Tilganger": [],
+                    "altinn3Tilganger": [],
+                    "underenheter": [
+                                            {
+                            "orgnr": "222222221",
+                            "navn": "UNDERENHET UTEN RETTIGHET",
+                            "altinn2Tilganger": [],
+                            "altinn3Tilganger": [],
+                            "underenheter": [],
+                            "organisasjonsform": "AS",
+                            "erSlettet": false
+                        }
+                    ],
+                    "organisasjonsform": "AS",
+                    "erSlettet": false
+                }
+            ],
+            "orgNrTilTilganger": {
+                "111111111": ["5078:1"],
+                "111111112": ["5078:1"],
+                "222222222": [],
+                "222222221": []
+            },
+            "tilgangTilOrgNr": {
+                "5078:1": ["111111111", 111111112]
             }
         }
     """.trimIndent()

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/AltinnKlientTest.kt
@@ -48,6 +48,7 @@ class AltinnKlientTest {
     @BeforeEach
     fun reset() {
         wireMockServer.resetAll()
+        altinnKlient.tømCache()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/CacheTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/altinn/CacheTest.kt
@@ -2,7 +2,7 @@ package no.nav.arbeidsgiver.toi.presentertekandidater.altinn
 
 
 import no.nav.arbeidsgiver.toi.presentertekandidater.Testdata
-import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.ENKELTRETTIGHET_REKRUTTERING
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.NAV_REKRUTTERING_KANDIDATER
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.Cache.AltinnFiltrering.INGEN
 import no.nav.arbeidsgiver.toi.presentertekandidater.tilfeldigFødselsnummer
 import no.nav.arbeidsgiver.toi.presentertekandidater.tilfeldigVirksomhetsnummer
@@ -19,8 +19,8 @@ class CacheTest {
     val cache = Cache(cacheLevetid)
 
     @Test
-    fun `Caching fungerer med filtrering på enkeltrettighet rekruttering`() {
-        val filtrering = ENKELTRETTIGHET_REKRUTTERING
+    fun `Caching fungerer med filtrering på rettighet nav_rekruttering_kandidater`() {
+        val filtrering = NAV_REKRUTTERING_KANDIDATER
         val fødselsnummer = tilfeldigFødselsnummer()
         val organisasjoner = listOf(
             Testdata.lagAltinnOrganisasjon(orgNummer = tilfeldigVirksomhetsnummer()),
@@ -57,7 +57,7 @@ class CacheTest {
             cache.leggICache(fødselsnummer, emptyList(), INGEN)
         }
         assertThrows<IllegalArgumentException> {
-            cache.leggICache(fødselsnummer, emptyList(), ENKELTRETTIGHET_REKRUTTERING)
+            cache.leggICache(fødselsnummer, emptyList(), NAV_REKRUTTERING_KANDIDATER)
         }
     }
 
@@ -67,7 +67,7 @@ class CacheTest {
         val organisasjonerUtenFiltrering = Testdata.lagAltinnOrganisasjon(orgNummer = tilfeldigVirksomhetsnummer())
         cache.leggICache(fødselsnummer, listOf(organisasjonerUtenFiltrering), INGEN)
 
-        val fraCache = cache.hentFraCache(fødselsnummer, ENKELTRETTIGHET_REKRUTTERING)
+        val fraCache = cache.hentFraCache(fødselsnummer, NAV_REKRUTTERING_KANDIDATER)
 
         assertNull(fraCache)
     }

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/DeleteKandidatTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/DeleteKandidatTest.kt
@@ -41,7 +41,7 @@ class DeleteKandidatTest {
             sistEndret = ZonedDateTime.now()
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -74,7 +74,7 @@ class DeleteKandidatTest {
             sistEndret = ZonedDateTime.now()
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummerManHarRettighetTil))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummerManHarRettighetTil))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -107,7 +107,7 @@ class DeleteKandidatTest {
             sistEndret = ZonedDateTime.now()
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val (_, response) = fuel
@@ -124,7 +124,7 @@ class DeleteKandidatTest {
         val virksomhetsnummer = "987654321"
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val kandidatUuidSomIkkeFinnes = UUID.randomUUID()

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/DeleteKandidatTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/DeleteKandidatTest.kt
@@ -41,8 +41,8 @@ class DeleteKandidatTest {
             sistEndret = ZonedDateTime.now()
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -74,8 +74,8 @@ class DeleteKandidatTest {
             sistEndret = ZonedDateTime.now()
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummerManHarRettighetTil))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummerManHarRettighetTil))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -107,8 +107,8 @@ class DeleteKandidatTest {
             sistEndret = ZonedDateTime.now()
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val (_, response) = fuel
             .delete("http://localhost:9000/kandidat/${kandidat.uuid}")
@@ -124,8 +124,8 @@ class DeleteKandidatTest {
         val virksomhetsnummer = "987654321"
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val kandidatUuidSomIkkeFinnes = UUID.randomUUID()
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/DeleteKandidatTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/DeleteKandidatTest.kt
@@ -42,7 +42,7 @@ class DeleteKandidatTest {
         )
         repository.lagre(kandidat)
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -75,7 +75,7 @@ class DeleteKandidatTest {
         )
         repository.lagre(kandidat)
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummerManHarRettighetTil))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -108,7 +108,7 @@ class DeleteKandidatTest {
         )
         repository.lagre(kandidat)
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val (_, response) = fuel
             .delete("http://localhost:9000/kandidat/${kandidat.uuid}")
@@ -125,7 +125,7 @@ class DeleteKandidatTest {
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val kandidatUuidSomIkkeFinnes = UUID.randomUUID()
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/DeleteKandidatTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/DeleteKandidatTest.kt
@@ -41,8 +41,8 @@ class DeleteKandidatTest {
             sistEndret = ZonedDateTime.now()
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -74,8 +74,8 @@ class DeleteKandidatTest {
             sistEndret = ZonedDateTime.now()
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummerManHarRettighetTil))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummerManHarRettighetTil))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -107,8 +107,8 @@ class DeleteKandidatTest {
             sistEndret = ZonedDateTime.now()
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val (_, response) = fuel
             .delete("http://localhost:9000/kandidat/${kandidat.uuid}")
@@ -124,8 +124,8 @@ class DeleteKandidatTest {
         val virksomhetsnummer = "987654321"
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val kandidatUuidSomIkkeFinnes = UUID.randomUUID()
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetAntallKandidaterTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetAntallKandidaterTest.kt
@@ -50,10 +50,10 @@ class GetAntallKandidaterTest {
     @Test
     fun `Svarer 400 Bad Request hvis URL-en ikke inneholder virksomhetsnummer`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "987654321"),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val (_, response) = fuel
@@ -74,9 +74,9 @@ class GetAntallKandidaterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
 
@@ -101,9 +101,9 @@ class GetAntallKandidaterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -125,9 +125,9 @@ class GetAntallKandidaterTest {
         val virksomhetsnummer = "323534343"
 
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -159,9 +159,9 @@ class GetAntallKandidaterTest {
         val kandidat = lagKandidatTilKandidatliste(kandidatliste?.id!!)
         repository.lagre(kandidat)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -184,9 +184,9 @@ class GetAntallKandidaterTest {
         val virksomhetsnummerManRepresenterer = tilfeldigVirksomhetsnummer()
 
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummerManRepresenterer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummerManRepresenterer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetAntallKandidaterTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetAntallKandidaterTest.kt
@@ -53,7 +53,7 @@ class GetAntallKandidaterTest {
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "123456789"),
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "987654321"),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val (_, response) = fuel
@@ -76,7 +76,7 @@ class GetAntallKandidaterTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
 
@@ -103,7 +103,7 @@ class GetAntallKandidaterTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -127,7 +127,7 @@ class GetAntallKandidaterTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -161,7 +161,7 @@ class GetAntallKandidaterTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -186,7 +186,7 @@ class GetAntallKandidaterTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummerManRepresenterer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetAntallKandidaterTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetAntallKandidaterTest.kt
@@ -50,8 +50,8 @@ class GetAntallKandidaterTest {
     @Test
     fun `Svarer 400 Bad Request hvis URL-en ikke inneholder virksomhetsnummer`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgang("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "987654321"),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -74,7 +74,7 @@ class GetAntallKandidaterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
@@ -101,7 +101,7 @@ class GetAntallKandidaterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
@@ -125,7 +125,7 @@ class GetAntallKandidaterTest {
         val virksomhetsnummer = "323534343"
 
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
@@ -159,7 +159,7 @@ class GetAntallKandidaterTest {
         val kandidat = lagKandidatTilKandidatliste(kandidatliste?.id!!)
         repository.lagre(kandidat)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
@@ -184,7 +184,7 @@ class GetAntallKandidaterTest {
         val virksomhetsnummerManRepresenterer = tilfeldigVirksomhetsnummer()
 
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummerManRepresenterer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummerManRepresenterer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetAntallKandidaterTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetAntallKandidaterTest.kt
@@ -50,10 +50,10 @@ class GetAntallKandidaterTest {
     @Test
     fun `Svarer 400 Bad Request hvis URL-en ikke inneholder virksomhetsnummer`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", "123456789"),
-            Testdata.lagAltinnOrganisasjon("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgang("Et Navn", "987654321"),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val (_, response) = fuel
@@ -74,9 +74,9 @@ class GetAntallKandidaterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
 
@@ -101,9 +101,9 @@ class GetAntallKandidaterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -125,9 +125,9 @@ class GetAntallKandidaterTest {
         val virksomhetsnummer = "323534343"
 
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -159,9 +159,9 @@ class GetAntallKandidaterTest {
         val kandidat = lagKandidatTilKandidatliste(kandidatliste?.id!!)
         repository.lagre(kandidat)
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -184,9 +184,9 @@ class GetAntallKandidaterTest {
         val virksomhetsnummerManRepresenterer = tilfeldigVirksomhetsnummer()
 
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummerManRepresenterer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummerManRepresenterer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetEnKandidatlisteTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetEnKandidatlisteTest.kt
@@ -36,7 +36,7 @@ class GetEnKandidatlisteTest {
         val nå = ZonedDateTime.now()
         val virksomhetsnummer = "111111111"
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
@@ -115,7 +115,7 @@ class GetEnKandidatlisteTest {
         val nå = ZonedDateTime.now()
         val virksomhetsnummer = "111111111"
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
@@ -170,7 +170,7 @@ class GetEnKandidatlisteTest {
         val nå = ZonedDateTime.now()
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(
             wiremockServer,
-            listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummerManRepresenterer))
+            listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummerManRepresenterer))
         )
         repository.lagre(
             kandidatliste().copy(
@@ -217,7 +217,7 @@ class GetEnKandidatlisteTest {
         val endepunkt = "http://localhost:9000/kandidatliste/$stillingId"
         val virksomhetsnummer = "123456789"
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetEnKandidatlisteTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetEnKandidatlisteTest.kt
@@ -38,7 +38,7 @@ class GetEnKandidatlisteTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         repository.lagre(kandidatliste().copy(stillingId = stillingId, virksomhetsnummer = virksomhetsnummer))
 
@@ -117,7 +117,7 @@ class GetEnKandidatlisteTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         repository.lagre(kandidatliste().copy(stillingId = stillingId, virksomhetsnummer = virksomhetsnummer))
 
@@ -168,7 +168,7 @@ class GetEnKandidatlisteTest {
         val stillingId = UUID.fromString("4bd2c240-92d2-4166-ac54-ba3d21bfbc07")
         val endepunkt = "http://localhost:9000/kandidatliste/$stillingId"
         val nå = ZonedDateTime.now()
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(
+        stubHentingAvTilgangerFraAltinnProxy(
             wiremockServer,
             listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummerManRepresenterer))
         )
@@ -219,7 +219,7 @@ class GetEnKandidatlisteTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         repository.lagre(
             kandidatliste().copy(

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetEnKandidatlisteTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetEnKandidatlisteTest.kt
@@ -36,9 +36,9 @@ class GetEnKandidatlisteTest {
         val nå = ZonedDateTime.now()
         val virksomhetsnummer = "111111111"
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         repository.lagre(kandidatliste().copy(stillingId = stillingId, virksomhetsnummer = virksomhetsnummer))
 
@@ -115,9 +115,9 @@ class GetEnKandidatlisteTest {
         val nå = ZonedDateTime.now()
         val virksomhetsnummer = "111111111"
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         repository.lagre(kandidatliste().copy(stillingId = stillingId, virksomhetsnummer = virksomhetsnummer))
 
@@ -168,9 +168,9 @@ class GetEnKandidatlisteTest {
         val stillingId = UUID.fromString("4bd2c240-92d2-4166-ac54-ba3d21bfbc07")
         val endepunkt = "http://localhost:9000/kandidatliste/$stillingId"
         val nå = ZonedDateTime.now()
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(
             wiremockServer,
-            listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummerManRepresenterer))
+            listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummerManRepresenterer))
         )
         repository.lagre(
             kandidatliste().copy(
@@ -217,9 +217,9 @@ class GetEnKandidatlisteTest {
         val endepunkt = "http://localhost:9000/kandidatliste/$stillingId"
         val virksomhetsnummer = "123456789"
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         repository.lagre(
             kandidatliste().copy(

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetEnKandidatlisteTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetEnKandidatlisteTest.kt
@@ -36,9 +36,9 @@ class GetEnKandidatlisteTest {
         val nå = ZonedDateTime.now()
         val virksomhetsnummer = "111111111"
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         repository.lagre(kandidatliste().copy(stillingId = stillingId, virksomhetsnummer = virksomhetsnummer))
 
@@ -115,9 +115,9 @@ class GetEnKandidatlisteTest {
         val nå = ZonedDateTime.now()
         val virksomhetsnummer = "111111111"
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         repository.lagre(kandidatliste().copy(stillingId = stillingId, virksomhetsnummer = virksomhetsnummer))
 
@@ -168,9 +168,9 @@ class GetEnKandidatlisteTest {
         val stillingId = UUID.fromString("4bd2c240-92d2-4166-ac54-ba3d21bfbc07")
         val endepunkt = "http://localhost:9000/kandidatliste/$stillingId"
         val nå = ZonedDateTime.now()
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(
             wiremockServer,
-            listOf(Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummerManRepresenterer))
+            listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummerManRepresenterer))
         )
         repository.lagre(
             kandidatliste().copy(
@@ -217,9 +217,9 @@ class GetEnKandidatlisteTest {
         val endepunkt = "http://localhost:9000/kandidatliste/$stillingId"
         val virksomhetsnummer = "123456789"
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         repository.lagre(
             kandidatliste().copy(

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
@@ -4,9 +4,10 @@ import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.jackson.responseObject
 import com.github.tomakehurst.wiremock.client.WireMock
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee
 import no.nav.arbeidsgiver.toi.presentertekandidater.*
 import no.nav.arbeidsgiver.toi.presentertekandidater.Testdata.kandidatliste
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnReportee
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnTilgang
 import no.nav.arbeidsgiver.toi.presentertekandidater.kandidatliste.Kandidatliste
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
@@ -56,10 +57,10 @@ class GetKandidatlisterTest {
     @Test
     fun `Svarer 400 Bad Request hvis URL-en ikke inneholder virksomhetsnummer`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", "123456789"),
-            Testdata.lagAltinnOrganisasjon("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgang("Et Navn", "987654321"),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val endepunkt = "http://localhost:9000/kandidatlister"
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -82,9 +83,9 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
 
@@ -107,9 +108,9 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -155,8 +156,8 @@ class GetKandidatlisterTest {
         repository.lagre(kandidatlisteOpprettet1UkeSiden)
         repository.lagre(kandidatlisteOpprettet1ÅrSiden)
         repository.lagre(kandidatlisteOpprettet1MånedSiden)
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -191,9 +192,9 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummerManHarRettighetTil),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummerManHarRettighetTil),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -210,10 +211,10 @@ class GetKandidatlisterTest {
     @Test
     fun `Skal bruke Altinn-cache`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", "123456789"),
-            Testdata.lagAltinnOrganisasjon("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgang("Et Navn", "987654321"),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val accessToken = hentToken(fødselsnummer)
@@ -231,13 +232,13 @@ class GetKandidatlisterTest {
         assertThat(respons2.statusCode).isEqualTo(200)
 
         wiremockServer.verify(1, WireMock.postRequestedFor(WireMock.urlEqualTo(tokenXWiremockUrl)))
-        wiremockServer.verify(1, WireMock.getRequestedFor(WireMock.urlEqualTo(altinnProxyUrlFiltrertPåRekruttering)))
+        wiremockServer.verify(1, WireMock.postRequestedFor(WireMock.urlEqualTo(altinnProxyUrl)))
     }
 
     @Test
     fun `Bruker ikke cache når Altinn returnerer tom liste av organisasjoner`() {
-        val tomListeAvOrganisasjoner = listOf<AltinnReportee>()
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, tomListeAvOrganisasjoner)
+        val tomListeAvOrganisasjoner = listOf<AltinnTilgang>()
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, tomListeAvOrganisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val accessToken = hentToken(fødselsnummer)
@@ -253,7 +254,7 @@ class GetKandidatlisterTest {
             .responseObject<List<AltinnReportee>>()
 
         wiremockServer.verify(2, WireMock.postRequestedFor(WireMock.urlEqualTo(tokenXWiremockUrl)))
-        wiremockServer.verify(2, WireMock.getRequestedFor(WireMock.urlEqualTo(altinnProxyUrlFiltrertPåRekruttering)))
+        wiremockServer.verify(2, WireMock.postRequestedFor(WireMock.urlEqualTo(altinnProxyUrl)))
     }
 
     @Test
@@ -269,9 +270,9 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
@@ -60,7 +60,7 @@ class GetKandidatlisterTest {
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "123456789"),
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "987654321"),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
         val endepunkt = "http://localhost:9000/kandidatlister"
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -85,7 +85,7 @@ class GetKandidatlisterTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
 
@@ -110,7 +110,7 @@ class GetKandidatlisterTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -157,7 +157,7 @@ class GetKandidatlisterTest {
         repository.lagre(kandidatlisteOpprettet1ÅrSiden)
         repository.lagre(kandidatlisteOpprettet1MånedSiden)
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -194,7 +194,7 @@ class GetKandidatlisterTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummerManHarRettighetTil),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -224,7 +224,7 @@ class GetKandidatlisterTest {
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "123456789"),
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "987654321"),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val accessToken = hentToken(fødselsnummer)
@@ -248,7 +248,7 @@ class GetKandidatlisterTest {
     @Test
     fun `Bruker ikke cache når Altinn returnerer tom liste av organisasjoner`() {
         val tomListeAvOrganisasjoner = listOf<AltinnTilgang>()
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, tomListeAvOrganisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, tomListeAvOrganisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val accessToken = hentToken(fødselsnummer)
@@ -282,7 +282,7 @@ class GetKandidatlisterTest {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
@@ -57,10 +57,10 @@ class GetKandidatlisterTest {
     @Test
     fun `Svarer 400 Bad Request hvis URL-en ikke inneholder virksomhetsnummer`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "987654321"),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
         val endepunkt = "http://localhost:9000/kandidatlister"
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -83,9 +83,9 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
 
@@ -108,9 +108,9 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -156,8 +156,8 @@ class GetKandidatlisterTest {
         repository.lagre(kandidatlisteOpprettet1UkeSiden)
         repository.lagre(kandidatlisteOpprettet1ÅrSiden)
         repository.lagre(kandidatlisteOpprettet1MånedSiden)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -192,9 +192,9 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummerManHarRettighetTil),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummerManHarRettighetTil),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -221,10 +221,10 @@ class GetKandidatlisterTest {
     @Test
     fun `Skal bruke Altinn-cache`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "987654321"),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val accessToken = hentToken(fødselsnummer)
@@ -248,7 +248,7 @@ class GetKandidatlisterTest {
     @Test
     fun `Bruker ikke cache når Altinn returnerer tom liste av organisasjoner`() {
         val tomListeAvOrganisasjoner = listOf<AltinnTilgang>()
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, tomListeAvOrganisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, tomListeAvOrganisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
         val accessToken = hentToken(fødselsnummer)
@@ -280,9 +280,9 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer),
         )
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
@@ -57,8 +57,8 @@ class GetKandidatlisterTest {
     @Test
     fun `Svarer 400 Bad Request hvis URL-en ikke inneholder virksomhetsnummer`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgang("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "987654321"),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val endepunkt = "http://localhost:9000/kandidatlister"
@@ -83,7 +83,7 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
@@ -108,7 +108,7 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
@@ -156,7 +156,7 @@ class GetKandidatlisterTest {
         repository.lagre(kandidatlisteOpprettet1UkeSiden)
         repository.lagre(kandidatlisteOpprettet1ÅrSiden)
         repository.lagre(kandidatlisteOpprettet1MånedSiden)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -192,7 +192,7 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummerManHarRettighetTil),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummerManHarRettighetTil),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
@@ -221,8 +221,8 @@ class GetKandidatlisterTest {
     @Test
     fun `Skal bruke Altinn-cache`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgang("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "987654321"),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -280,7 +280,7 @@ class GetKandidatlisterTest {
         )
         repository.lagre(kandidatliste)
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer),
+            Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer),
         )
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetKandidatlisterTest.kt
@@ -209,6 +209,16 @@ class GetKandidatlisterTest {
     }
 
     @Test
+    fun `Returnerer 503 når Altinn feiler`() {
+        stubHttpStatus500FraAltinnProxy(wiremockServer)
+        val (_, response) = fuel
+            .get("http://localhost:9000/kandidatlister?virksomhetsnummer=987654321")
+            .authentication().bearer(hentToken(tilfeldigFødselsnummer()))
+            .response()
+        assertThat(response.statusCode).isEqualTo(503)
+    }
+
+    @Test
     fun `Skal bruke Altinn-cache`() {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgang("Et Navn", "123456789"),

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetOrganisasjonerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetOrganisasjonerTest.kt
@@ -4,8 +4,9 @@ import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.jackson.responseObject
 import com.github.tomakehurst.wiremock.client.WireMock
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee
 import no.nav.arbeidsgiver.toi.presentertekandidater.*
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnReportee
+import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnTilgang
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.*
 
@@ -27,10 +28,11 @@ class GetOrganisasjonerTest {
     @Test
     fun `Returnerer 200 og liste over alle organisasjoner der bruker har en rolle`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", "123456789"),
-            Testdata.lagAltinnOrganisasjon("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgang("Et Navn", "123456789")
         )
-        stubHentingAvOrganisasjonerFraAltinnProxy(wiremockServer, organisasjoner)
+
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val (_, respons, result) = fuel
             .get("http://localhost:9000/organisasjoner")
@@ -46,8 +48,8 @@ class GetOrganisasjonerTest {
 
     @Test
     fun `Returnerer 200 og tom liste hvis bruker ikke har rolle i noen organisasjoner`() {
-        val organisasjoner = emptyList<AltinnReportee>()
-        stubHentingAvOrganisasjonerFraAltinnProxy(wiremockServer, organisasjoner)
+        val organisasjoner = emptyList<AltinnTilgang>()
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val (_, respons, result) = fuel
             .get("http://localhost:9000/organisasjoner")
@@ -63,10 +65,10 @@ class GetOrganisasjonerTest {
     @Test
     fun `Skal bruke cache i Altinn-klient`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", "123456789"),
-            Testdata.lagAltinnOrganisasjon("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgang("Et Navn", "987654321"),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxy(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         val (_, respons1, result1) = fuel
@@ -88,6 +90,6 @@ class GetOrganisasjonerTest {
         Assertions.assertThat(organisasjonerFraRespons2).hasSize(organisasjoner.size)
 
         wiremockServer.verify(1, WireMock.postRequestedFor(WireMock.urlEqualTo(tokenXWiremockUrl)))
-        wiremockServer.verify(1, WireMock.getRequestedFor(WireMock.urlEqualTo(altinnProxyUrl)))
+        wiremockServer.verify(1, WireMock.postRequestedFor(WireMock.urlEqualTo(altinnProxyUrl)))
     }
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetOrganisasjonerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetOrganisasjonerTest.kt
@@ -28,8 +28,8 @@ class GetOrganisasjonerTest {
     @Test
     fun `Returnerer 200 og liste over alle organisasjoner der bruker har en rolle`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgang("Et Navn", "123456789")
+            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "123456789")
         )
 
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
@@ -65,8 +65,8 @@ class GetOrganisasjonerTest {
     @Test
     fun `Skal bruke cache i Altinn-klient`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgang("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "987654321"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetOrganisasjonerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetOrganisasjonerTest.kt
@@ -29,7 +29,7 @@ class GetOrganisasjonerTest {
     fun `Returnerer 200 og liste over alle organisasjoner der bruker har en rolle`() {
         val organisasjoner = listOf(
             Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "123456789")
+            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "987654321")
         )
 
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetOrganisasjonerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/GetOrganisasjonerTest.kt
@@ -28,8 +28,8 @@ class GetOrganisasjonerTest {
     @Test
     fun `Returnerer 200 og liste over alle organisasjoner der bruker har en rolle`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "987654321")
+            Testdata.lagAltinnTilgangUtenRettighetKandidater("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangUtenRettighetKandidater("Et Navn", "987654321")
         )
 
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
@@ -65,8 +65,8 @@ class GetOrganisasjonerTest {
     @Test
     fun `Skal bruke cache i Altinn-klient`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "123456789"),
-            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "987654321"),
+            Testdata.lagAltinnTilgangUtenRettighetKandidater("Et Navn", "123456789"),
+            Testdata.lagAltinnTilgangUtenRettighetKandidater("Et Navn", "987654321"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/PutVurderingTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/PutVurderingTest.kt
@@ -39,8 +39,8 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -77,8 +77,8 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         val accessToken = hentToken(fødselsnummer)
@@ -111,8 +111,8 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val body = """
             {
@@ -136,8 +136,8 @@ class PutVurderingTest {
 
     @Test
     fun `Kall med ukjent verdi i vurderingsfeltet skal returnere 400`() {
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "53987549"))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "53987549"))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
         val body = """
             {
               "arbeidsgiversVurdering": "NY"
@@ -157,8 +157,8 @@ class PutVurderingTest {
 
     @Test
     fun `Gir 400 hvis kandidat ikke eksisterer`() {
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "221133445"))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "221133445"))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
         val body = """
             {
               "arbeidsgiversVurdering": "FÅTT_JOBBEN"
@@ -196,8 +196,8 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", innloggetBrukersVirksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", innloggetBrukersVirksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
         val body = """
             {
               "arbeidsgiversVurdering": "FÅTT_JOBBEN"

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/PutVurderingTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/PutVurderingTest.kt
@@ -39,7 +39,7 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -77,7 +77,7 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -111,7 +111,7 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", virksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val body = """
@@ -136,7 +136,7 @@ class PutVurderingTest {
 
     @Test
     fun `Kall med ukjent verdi i vurderingsfeltet skal returnere 400`() {
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", "53987549"))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "53987549"))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val body = """
             {
@@ -157,7 +157,7 @@ class PutVurderingTest {
 
     @Test
     fun `Gir 400 hvis kandidat ikke eksisterer`() {
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", "221133445"))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", "221133445"))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val body = """
             {
@@ -196,7 +196,7 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", innloggetBrukersVirksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", innloggetBrukersVirksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val body = """
             {

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/PutVurderingTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/PutVurderingTest.kt
@@ -39,8 +39,8 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -77,8 +77,8 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         val accessToken = hentToken(fødselsnummer)
@@ -111,8 +111,8 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", virksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val body = """
             {
@@ -136,8 +136,8 @@ class PutVurderingTest {
 
     @Test
     fun `Kall med ukjent verdi i vurderingsfeltet skal returnere 400`() {
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", "53987549"))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", "53987549"))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val body = """
             {
               "arbeidsgiversVurdering": "NY"
@@ -157,8 +157,8 @@ class PutVurderingTest {
 
     @Test
     fun `Gir 400 hvis kandidat ikke eksisterer`() {
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", "221133445"))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", "221133445"))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val body = """
             {
               "arbeidsgiversVurdering": "FÅTT_JOBBEN"
@@ -196,8 +196,8 @@ class PutVurderingTest {
             sistEndret = ZonedDateTime.now().minusDays(1)
         )
         repository.lagre(kandidat)
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", innloggetBrukersVirksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", innloggetBrukersVirksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
         val body = """
             {
               "arbeidsgiversVurdering": "FÅTT_JOBBEN"

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/PutVurderingTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/PutVurderingTest.kt
@@ -40,7 +40,7 @@ class PutVurderingTest {
         )
         repository.lagre(kandidat)
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -78,7 +78,7 @@ class PutVurderingTest {
         )
         repository.lagre(kandidat)
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         val accessToken = hentToken(fødselsnummer)
@@ -112,7 +112,7 @@ class PutVurderingTest {
         )
         repository.lagre(kandidat)
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val body = """
             {
@@ -137,7 +137,7 @@ class PutVurderingTest {
     @Test
     fun `Kall med ukjent verdi i vurderingsfeltet skal returnere 400`() {
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "53987549"))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
         val body = """
             {
               "arbeidsgiversVurdering": "NY"
@@ -158,7 +158,7 @@ class PutVurderingTest {
     @Test
     fun `Gir 400 hvis kandidat ikke eksisterer`() {
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", "221133445"))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
         val body = """
             {
               "arbeidsgiversVurdering": "FÅTT_JOBBEN"
@@ -197,7 +197,7 @@ class PutVurderingTest {
         )
         repository.lagre(kandidat)
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", innloggetBrukersVirksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
         val body = """
             {
               "arbeidsgiversVurdering": "FÅTT_JOBBEN"

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
@@ -44,8 +44,8 @@ class RegistrerVisningTest {
     fun `Skal oppdatere registrering av visning og returnere 200 OK`() {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat = kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!))
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", kandidatliste.virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", kandidatliste.virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -67,8 +67,8 @@ class RegistrerVisningTest {
 
     @Test
     fun `Skal returnere 400 om man prøver registrere visning av kandidat som ikke finnes`() {
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", tilfeldigVirksomhetsnummer()))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", tilfeldigVirksomhetsnummer()))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -89,12 +89,12 @@ class RegistrerVisningTest {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat =
             kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!, aktørId = "987"))
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", kandidatliste.virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", kandidatliste.virksomhetsnummer))
 
 
         try {
             renameDatabaseTabell("visning_kontaktinfo", "feil")
-            stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+            stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
             val fødselsnummer = tilfeldigFødselsnummer()
             lagreSamtykke(fødselsnummer)
             val accessToken = hentToken(fødselsnummer)
@@ -121,8 +121,8 @@ class RegistrerVisningTest {
     fun `Skal lagre registrering av visning med publisert_melding lik false`() {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat = kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!))
-        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", kandidatliste.virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", kandidatliste.virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
@@ -44,8 +44,8 @@ class RegistrerVisningTest {
     fun `Skal oppdatere registrering av visning og returnere 200 OK`() {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat = kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!))
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", kandidatliste.virksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", kandidatliste.virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -67,8 +67,8 @@ class RegistrerVisningTest {
 
     @Test
     fun `Skal returnere 400 om man prøver registrere visning av kandidat som ikke finnes`() {
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", tilfeldigVirksomhetsnummer()))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", tilfeldigVirksomhetsnummer()))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -89,12 +89,12 @@ class RegistrerVisningTest {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat =
             kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!, aktørId = "987"))
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", kandidatliste.virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", kandidatliste.virksomhetsnummer))
 
 
         try {
             renameDatabaseTabell("visning_kontaktinfo", "feil")
-            stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+            stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
             val fødselsnummer = tilfeldigFødselsnummer()
             lagreSamtykke(fødselsnummer)
             val accessToken = hentToken(fødselsnummer)
@@ -121,8 +121,8 @@ class RegistrerVisningTest {
     fun `Skal lagre registrering av visning med publisert_melding lik false`() {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat = kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!))
-        val organisasjoner = listOf(Testdata.lagAltinnOrganisasjon("Et Navn", kandidatliste.virksomhetsnummer))
-        stubHentingAvOrganisasjonerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
+        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", kandidatliste.virksomhetsnummer))
+        stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
@@ -44,7 +44,7 @@ class RegistrerVisningTest {
     fun `Skal oppdatere registrering av visning og returnere 200 OK`() {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat = kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!))
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", kandidatliste.virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", kandidatliste.virksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -67,7 +67,7 @@ class RegistrerVisningTest {
 
     @Test
     fun `Skal returnere 400 om man prøver registrere visning av kandidat som ikke finnes`() {
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", tilfeldigVirksomhetsnummer()))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", tilfeldigVirksomhetsnummer()))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -89,7 +89,7 @@ class RegistrerVisningTest {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat =
             kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!, aktørId = "987"))
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", kandidatliste.virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", kandidatliste.virksomhetsnummer))
 
 
         try {
@@ -121,7 +121,7 @@ class RegistrerVisningTest {
     fun `Skal lagre registrering av visning med publisert_melding lik false`() {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat = kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!))
-        val organisasjoner = listOf(Testdata.lagAltinnTilgang("Et Navn", kandidatliste.virksomhetsnummer))
+        val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRekrutteringsrettighet("Et Navn", kandidatliste.virksomhetsnummer))
         stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/RegistrerVisningTest.kt
@@ -45,7 +45,7 @@ class RegistrerVisningTest {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat = kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!))
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", kandidatliste.virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -68,7 +68,7 @@ class RegistrerVisningTest {
     @Test
     fun `Skal returnere 400 om man prøver registrere visning av kandidat som ikke finnes`() {
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", tilfeldigVirksomhetsnummer()))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)
@@ -94,7 +94,7 @@ class RegistrerVisningTest {
 
         try {
             renameDatabaseTabell("visning_kontaktinfo", "feil")
-            stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+            stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
             val fødselsnummer = tilfeldigFødselsnummer()
             lagreSamtykke(fødselsnummer)
             val accessToken = hentToken(fødselsnummer)
@@ -122,7 +122,7 @@ class RegistrerVisningTest {
         val kandidatliste = kandidatlisteRepository.lagre(Testdata.kandidatliste())
         val kandidat = kandidatlisteRepository.lagre(Testdata.lagKandidatTilKandidatliste(kandidatliste.id!!))
         val organisasjoner = listOf(Testdata.lagAltinnTilgangMedRettighetKandidater("Et Navn", kandidatliste.virksomhetsnummer))
-        stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         lagreSamtykke(fødselsnummer)

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/SamtykkeTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/SamtykkeTest.kt
@@ -9,7 +9,6 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.net.http.HttpResponse.BodyHandlers
-import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SamtykkeTest {
@@ -39,7 +38,7 @@ class SamtykkeTest {
     @Test
     fun `Skal returnere 403 hvis du ikke har samtykket Deprekert`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgangUtenRettighetKandidater("Et Navn", "111111111"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
@@ -53,7 +52,7 @@ class SamtykkeTest {
     @Test
     fun `Skal lagre samtykke på innlogget bruker`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgangUtenRettighetKandidater("Et Navn", "111111111"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
@@ -71,7 +70,7 @@ class SamtykkeTest {
     @Test
     fun `Skal returnere 200 OK selv om samtykke allerede finnes`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgangUtenRettighetKandidater("Et Navn", "111111111"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -114,7 +113,7 @@ class SamtykkeTest {
     @Test
     fun `Skal returnere 200 OK men false hvis du ikke har samtykket`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgangUtenRettighetKandidater("Et Navn", "111111111"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/SamtykkeTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/SamtykkeTest.kt
@@ -39,7 +39,7 @@ class SamtykkeTest {
     @Test
     fun `Skal returnere 403 hvis du ikke har samtykket Deprekert`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "111111111"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
@@ -53,7 +53,7 @@ class SamtykkeTest {
     @Test
     fun `Skal lagre samtykke på innlogget bruker`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "111111111"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
@@ -71,7 +71,7 @@ class SamtykkeTest {
     @Test
     fun `Skal returnere 200 OK selv om samtykke allerede finnes`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "111111111"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
@@ -114,7 +114,7 @@ class SamtykkeTest {
     @Test
     fun `Skal returnere 200 OK men false hvis du ikke har samtykket`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnTilgang("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgangUtenRekrutteringsrettighet("Et Navn", "111111111"),
         )
         stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/SamtykkeTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/controllertester/SamtykkeTest.kt
@@ -39,9 +39,9 @@ class SamtykkeTest {
     @Test
     fun `Skal returnere 403 hvis du ikke har samtykket Deprekert`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgang("Et Navn", "111111111"),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxy(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val request = HttpRequest.newBuilder(URI("http://localhost:9000/samtykke"))
             .header("Authorization", "Bearer ${hentToken(tilfeldigFødselsnummer())}")
@@ -53,9 +53,9 @@ class SamtykkeTest {
     @Test
     fun `Skal lagre samtykke på innlogget bruker`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgang("Et Navn", "111111111"),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxy(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val fødselsnummer = tilfeldigFødselsnummer()
         val request = HttpRequest.newBuilder(URI("http://localhost:9000/samtykke"))
@@ -71,9 +71,9 @@ class SamtykkeTest {
     @Test
     fun `Skal returnere 200 OK selv om samtykke allerede finnes`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgang("Et Navn", "111111111"),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxy(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
         val fødselsnummer = tilfeldigFødselsnummer()
 
         val request = HttpRequest.newBuilder(URI("http://localhost:9000/samtykke"))
@@ -114,9 +114,9 @@ class SamtykkeTest {
     @Test
     fun `Skal returnere 200 OK men false hvis du ikke har samtykket`() {
         val organisasjoner = listOf(
-            Testdata.lagAltinnOrganisasjon("Et Navn", "111111111"),
+            Testdata.lagAltinnTilgang("Et Navn", "111111111"),
         )
-        stubHentingAvOrganisasjonerFraAltinnProxy(wiremockServer, organisasjoner)
+        stubHentingAvTilgangerFraAltinnProxy(wiremockServer, organisasjoner)
 
         val request = HttpRequest.newBuilder(URI("http://localhost:9000/hentsamtykke"))
             .header("Authorization", "Bearer ${hentToken(tilfeldigFødselsnummer())}")

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
@@ -2,7 +2,6 @@ package no.nav.arbeidsgiver.toi.presentertekandidater
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnReportee
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnTilgang
 import no.nav.arbeidsgiver.toi.presentertekandidater.altinn.AltinnTilgangerResponse
 import no.nav.arbeidsgiver.toi.presentertekandidater.samtykke.SamtykkeRepository
@@ -113,6 +112,21 @@ fun stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(
             .willReturn(
                 WireMock.ok(organisasjonerJson)
                     .withHeader("Content-Type", "application/json")
+            )
+    )
+}
+
+fun stubHttpStatus500FraAltinnProxy(wiremockServer: WireMockServer) {
+    val exchangeToken = "exchangeToken"
+    stubVekslingAvTokenX(wiremockServer, exchangeToken)
+
+    wiremockServer.stubFor(
+        WireMock.get(altinnProxyUrl)
+            .withHeader("Authorization", WireMock.containing("Bearer $exchangeToken"))
+            .willReturn(
+                WireMock.serverError()
+                    .withStatus(500)
+                    .withStatusMessage("Noe gikk galt")
             )
     )
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
@@ -82,7 +82,7 @@ fun stubHentingAvTilgangerFraAltinnProxy(wiremockServer: WireMockServer, altinnT
     )
 }
 
-fun stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(
+fun stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(
     wiremockServer: WireMockServer,
     altinnTilganger: List<AltinnTilgang>
 ) {

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
@@ -126,7 +126,7 @@ fun stubHttpStatus500FraAltinnProxy(wiremockServer: WireMockServer) {
     stubVekslingAvTokenX(wiremockServer, exchangeToken)
 
     wiremockServer.stubFor(
-        WireMock.get(altinnProxyUrl)
+        WireMock.post(altinnProxyUrl)
             .withHeader("Authorization", WireMock.containing("Bearer $exchangeToken"))
             .willReturn(
                 WireMock.serverError()

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
@@ -96,10 +96,15 @@ fun stubHentingAvTilgangerFraAltinnProxyFiltrertPåRekruttering(
             it.orgnr to listOf(it.altinn3Tilganger, it.altinn2Tilganger).flatten().toSet()
         },
         tilgangTilOrgNr = altinnTilganger.flatMap { tilgang ->
-            listOf(
-                tilgang.altinn2Tilganger to tilgang.orgnr,
-                tilgang.altinn3Tilganger to tilgang.orgnr
-            )
+            fun flatUtTilganger(tilgang: AltinnTilgang): List<Pair<List<String>, String>> {
+                val nåværendeTilgang = listOf(
+                    tilgang.altinn2Tilganger.toList() to tilgang.orgnr,
+                    tilgang.altinn3Tilganger.toList() to tilgang.orgnr
+                )
+                val underenhetTilganger = tilgang.underenheter.flatMap { flatUtTilganger(it) }
+                return nåværendeTilgang + underenhetTilganger
+            }
+            flatUtTilganger(tilgang)
         }.flatMap { (tilganger, orgnr) ->
             tilganger.map { it to orgnr }
         }.groupBy({ it.first }, { it.second }).mapValues { it.value.toSet() }

--- a/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/toi/presentertekandidater/testUtils.kt
@@ -50,39 +50,7 @@ const val tokenXWiremockUrl = "/token-x-token-endpoint"
 
 const val altinnProxyUrl = "/altinn-proxy-url"
 
-//TODO: Denne er nå prikk lik som stubHentingAvtilgangerFraAltinnProxyFiltrertPåRekruttering. Enten slå dem sammen, eller endre oppførselen
-fun stubHentingAvTilgangerFraAltinnProxy(wiremockServer: WireMockServer, altinnTilganger: List<AltinnTilgang>) {
-    val exchangeToken = "exchangeToken"
-    stubVekslingAvTokenX(wiremockServer, exchangeToken)
-
-    val altinnTilgangerResponse = AltinnTilgangerResponse(
-        isError = false,
-        hierarki = altinnTilganger,
-        orgNrTilTilganger = altinnTilganger.associate {
-            it.orgnr to listOf(it.altinn3Tilganger, it.altinn2Tilganger).flatten().toSet()
-        },
-        tilgangTilOrgNr = altinnTilganger.flatMap { tilgang ->
-            listOf(
-                tilgang.altinn2Tilganger to tilgang.orgnr,
-                tilgang.altinn3Tilganger to tilgang.orgnr
-            )
-        }.flatMap { (tilganger, orgnr) ->
-            tilganger.map { it to orgnr }
-        }.groupBy({ it.first }, { it.second }).mapValues { it.value.toSet() }
-    )
-
-    val organisasjonerJson = objectMapper.writeValueAsString(altinnTilgangerResponse)
-    wiremockServer.stubFor(
-        WireMock.post(altinnProxyUrl)
-            .withHeader("Authorization", WireMock.containing("Bearer $exchangeToken"))
-            .willReturn(
-                WireMock.ok(organisasjonerJson)
-                    .withHeader("Content-Type", "application/json")
-            )
-    )
-}
-
-fun stubHentingAvTilgangerFraAltinnProxyFiltrertPåKandidater(
+fun stubHentingAvTilgangerFraAltinnProxy(
     wiremockServer: WireMockServer,
     altinnTilganger: List<AltinnTilgang>
 ) {


### PR DESCRIPTION
### Hva?
- Migrerer fra [altinn-rettigheter-proxy](https://github.com/navikt/altinn-rettigheter-proxy) til [arbeidsgiver-altinn-tilganger](https://arbeidsgiver-altinn-tilganger.intern.dev.nav.no/swagger-ui) for kommunikasjon med Altinn.
- Tar i bruk nyopprettet [Altinn3-ressurs](https://platform.tt02.altinn.no/resourceregistry/api/v1/resource/nav_rekruttering_kandidater) for tilgangsstyring. Denne er lagt til i tillegg til eksisterende rettighet fra altinn2.
- Migrerer fra securelogs til team logs. Dette er egentlig urelatert til altinn3-migreringen, men nødvendig for å fortsatt kunne lese disse logglinjene.

### Hvorfor?
Endringene er nødvendige for å fortsatt kunne bruke Altinn til tilgangsstyring etter at Altinn2 skrus av.

### Hvordan?
Kjernen i PR'en er AltinnKlient.kt og endringer i datastrukturene fra Altinn. 

AltinnReportee-objektet som opprinnelig ble brukt til tilgangsstyring i kontrolleren er beholdt, men felter som ikke var i bruk er fjernet. De nye altinnresponsene (AltinnTilgangerResponse) har fått ny struktur, særlig for å representere relasjonen mellom overordnede enheter og underenheter. Disse mappes til AltinnReportee-objekter og relasjonen mellom overordnede enheter og underenheter bevares.

AltinnKlienten har en retrymekanisme for driftsforstyrrelser, ref. anbefaling i [dokumentasjonen](https://arbeidsgiver-altinn-tilganger.intern.dev.nav.no/swagger-ui) til proxyen.

Nye tester er lagt til i AltinnKlientTest.kt og eksisterende tester, samt testUtils for stubbing av altinnresponser, er oppdatert.